### PR TITLE
Better errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
-## 0.2.1 - January 30, 2014
+## 0.3.0.pre - February 3, 2015
+
+- Separate IBAN splitting into IBANSplitter
+- Move IBANBuilder interface into main IBAN class by overloading its constructor
+- Move validation of local details input out of IBANBuilder into IBAN
+- Split `IBAN.valid_length?` into individual checks on the length of bank code, branch code, and account number
+
+## 0.2.1 - January 30, 2015
 
 - Add Lithuania to IBANBuilder
 
-## 0.2.0 - January 27, 2014
+## 0.2.0 - January 27, 2015
 
 - Add GermanDetailsConverter
 
 
-## 0.1.1 - January 8, 2014
+## 0.1.1 - January 8, 2015
 
 - Add zero-padding to CheckDigit.spanish
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ The following error keys may be set:
 - `country_code`
 - `check_digits`
 - `characters`
-- `length`
+- `bank_code`
+- `branch_code`
+- `account_number`
 - `format`
 
 ### Deconstructing an IBAN into national banking details
@@ -135,179 +137,179 @@ To build an IBAN from local details:
 
 ```ruby
 # Austria
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'AT',
   account_number: '234573201',
   bank_code: '19043'
 )
-iban.iban                     # => "AT611904300234573201"
+iban.to_s(:formatted)         # => "AT61 1904 3002 3457 3201"
 
 # Belgium
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'BE',
   account_number: '510-0075470-61'
 )
-iban.iban                     # => "BE62510007547061"
+iban.to_s(:formatted)         # => "BE62 5100 0754 7061"
 
 # Cyprus
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'CY',
   account_number: '1200527600',
   bank_code: '002',
   branch_code: '00128'
 )
-iban.iban                     # => "CY17002001280000001200527600"
+iban.to_s(:formatted)         # => "CY17 0020 0128 0000 0012 0052 7600"
 
 # Germany
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'DE',
   bank_code: '37040044',
   account_number: '0532013000'
 )
-iban.iban                     # => "DE89370400440532013000"
+iban.to_s(:formatted)         # => "DE89 3704 0044 0532 0130 00"
 
 # Estonia
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'EE',
   account_number: '111020145685'
 )
-iban.iban                     # => "EE412200111020145685"
+iban.to_s(:formatted)         # => "EE41 2200 1110 2014 5685"
 
 # Finland
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'FI',
   bank_code: '123456'
   account_number: '785'
 )
-iban.iban                     # => "FI2112345600000785"
+iban.to_s(:formatted)         # => "FI21 1234 5600 0007 85"
 
 # France
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'FR',
   bank_code: '20041',
   branch_code: '01005',
   account_number: '0500013M02606',
 )
-iban.iban                     # => "FR1420041010050500013M02606"
+iban.to_s(:formatted)         # => "FR14 2004 1010 0505 0001 3M02 606"
 
 # United Kingdom
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'GB',
   bank_code: 'BARC', # optional if a BIC finder is configured
   branch_code: '200000',
   account_number: '55779911'
 )
-iban.iban                     # => "GB60BARC20000055779911"
+iban.to_s(:formatted)         # => "GB60 BARC 2000 0055 7799 11"
 
 # Ireland
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'IE',
   bank_code: 'AIBK', # optional if a BIC finder is configured
   branch_code: '931152',
   account_number: '12345678'
 )
-iban.iban                     # => "IE29AIBK93115212345678"
+iban.to_s(:formatted)         # => "IE29 AIBK 9311 5212 3456 78"
 
 # Italy
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'IT',
   bank_code: '05428',
   branch_code: '11101',
   account_number: '000000123456'
 )
-iban.iban                     # => "IT60X0542811101000000123456"
+iban.to_s(:formatted)         # => "IT60 X054 2811 1010 0000 0123 456"
 
 # Latvia
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'LV',
   account_number: '1234567890123',
   bank_code: 'BANK'
 )
-iban.iban                     # => "LV72BANK1234567890123"
+iban.to_s(:formatted)         # => "LV72 BANK 1234 5678 9012 3"
 
 # Lithuania
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'LT',
   account_number: '11101001000',
   bank_code: '10000'
 )
-iban.iban                     # => "LT1000011101001000"
+iban.to_s(:formatted)         # => "LT10 0001 1101 0010 00"
 
 # Luxembourg
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'LU',
   account_number: '1234567890123',
   bank_code: 'BANK'
 )
-iban.iban                     # => "LU75BANK1234567890123"
+iban.to_s(:formatted)         # => "LU75 BANK 1234 5678 9012 3"
 
 # Monaco
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'MC',
   bank_code: '20041',
   branch_code: '01005',
   account_number: '0500013M026'
 )
-iban.iban                     # => "MC9320041010050500013M02606"
+iban.to_s(:formatted)         # => "MC93 2004 1010 0505 0001 3M02 606"
 
 # The Netherlands
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'NL',
   account_number: '0417164300',
   bank_code: 'ABNA'
 )
-iban.iban                     # => "NL91ABNA0417164300"
+iban.to_s(:formatted)         # => "NL91 ABNA 0417 1643 00"
 
 # Portugal
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'PT',
   bank_code: '0002',
   branch_code: '0023',
   account_number: '0023843000578'
 )
-iban.iban                     # => "PT50000200230023843000578"
+iban.to_s(:formatted)         # => "PT50 0002 0023 0023 8430 0057 8"
 
 # Slovakia
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'SK',
   bank_code: '1200',
   account_number_prefix: '19',
   account_number: '8742637541'
 )
-iban.iban                     # => "SK3112000000198742637541"
+iban.to_s(:formatted)         # => "SK31 1200 0000 1987 4263 7541"
 
 # Slovenia
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'SI',
   bank_code: '19100',
   account_number: '1234'
 )
-iban.iban                     # => "SI56191000000123438"
+iban.to_s(:formatted)         # => "SI56 1910 0000 0123 438"
 
 # Spain
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'ES',
   bank_code: '2310',
   branch_code: '0001',
   account_number: '180000012345'
 )
-iban.iban                     # => "ES8023100001180000012345"
+iban.to_s(:formatted)         # => "ES80 2310 0001 1800 0001 2345"
 
 # Spain with 20 digit account number
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'ES',
   account_number: '23100001180000012345'
 )
-iban.iban                     # => "ES8023100001180000012345"
+iban.to_s(:formatted)         # => "ES80 2310 0001 1800 0001 2345"
 
 # San Marino
-iban = Ibandit::IBANBuilder.build(
+iban = Ibandit::IBAN.new(
   country_code: 'SM',
   bank_code: '05428',
   branch_code: '11101',
   account_number: '000000123456'
 )
-iban.iban                     # => "SM88X0542811101000000123456"
+iban.to_s(:formatted)         # => "SM88 X054 2811 10100 0000 1234 56"
 ```
 
 Support for Greece and Malta is coming soon.

--- a/lib/ibandit.rb
+++ b/lib/ibandit.rb
@@ -3,6 +3,7 @@ require 'ibandit/errors'
 require 'ibandit/iban'
 require 'ibandit/german_details_converter'
 require 'ibandit/iban_builder'
+require 'ibandit/iban_splitter'
 require 'ibandit/check_digit'
 
 module Ibandit
@@ -12,6 +13,12 @@ module Ibandit
     def find_bic(country_code, national_id)
       raise NotImplementedError, 'BIC finder is not defined' unless @bic_finder
       @bic_finder.call(country_code, national_id)
+    end
+
+    def structures
+      @structures ||= YAML.load_file(
+        File.expand_path('../../data/structures.yml', __FILE__)
+      )
     end
   end
 end

--- a/lib/ibandit/iban_builder.rb
+++ b/lib/ibandit/iban_builder.rb
@@ -4,17 +4,16 @@ module Ibandit
                                  PT SI SK SM).freeze
 
     def self.build(opts)
-      country_code = opts.delete(:country_code)
+      country_code = opts[:country_code]
 
       if country_code.nil?
-        raise ArgumentError, 'You must provide a country_code'
+        return opts
       elsif !SUPPORTED_COUNTRY_CODES.include?(country_code)
-        msg = "Don't know how to build an IBAN for country code #{country_code}"
-        raise UnsupportedCountryError, msg
+        return opts
       else
-        require_fields(country_code, opts)
-        bban = send(:"build_#{country_code.downcase}_bban", opts)
-        build_iban(country_code, bban)
+        return opts unless has_required_fields?(country_code, opts)
+        bban_info = send(:"build_#{country_code.downcase}_bban_info", opts)
+        build_iban_parts(country_code, bban_info)
       end
     end
 
@@ -22,7 +21,7 @@ module Ibandit
     # Country-specific BBAN creation #
     ##################################
 
-    def self.build_at_bban(opts)
+    def self.build_at_bban_info(opts)
       # Local account details format:
       #   aaaaaaaaaaa bbbbb
       #   Account number may be 4-11 digits long
@@ -39,13 +38,17 @@ module Ibandit
       #
       # Padding:
       #   Add leading zeros to account number if < 11 digits.
-      [
-        opts[:bank_code],
-        opts[:account_number].rjust(11, '0')
-      ].join
+      bank_code      = opts[:bank_code]
+      account_number = opts[:account_number].rjust(11, '0')
+
+      {
+        bban:           bank_code + account_number,
+        bank_code:      bank_code,
+        account_number: account_number
+      }
     end
 
-    def self.build_be_bban(opts)
+    def self.build_be_bban_info(opts)
       # Local account details format: bbb-aaaaaaa-cc
       #
       # Local account details name(s):
@@ -65,10 +68,15 @@ module Ibandit
       #   numbers and the IBAN structure file includes them in its definition of
       #   the account number. As a result, this method ignores all arguments
       #   other than the account number.
-      opts[:account_number].tr('-', '')
+      account_number = opts[:account_number].tr('-', '')
+
+      {
+        bban:           account_number,
+        account_number: account_number
+      }
     end
 
-    def self.build_cy_bban(opts)
+    def self.build_cy_bban_info(opts)
       # Local account details format:
       #   bbb-sssss aaaaaaaaaaaaaaaa
       #   Account number may be 7-16 digits long
@@ -90,16 +98,26 @@ module Ibandit
       # Additional info:
       #   Cypriot bank and branch codes are often communicated as a single code,
       #   so this method handles being passed them together or separately.
-      combined_bank_code = opts[:bank_code]
-      combined_bank_code += opts[:branch_code] || ''
+      cleaned_bank_code = opts[:bank_code].gsub(/[-\s]/, '')
 
-      [
-        combined_bank_code,
-        opts[:account_number].rjust(16, '0')
-      ].join
+      bank_code      = cleaned_bank_code.slice(0, 3)
+      branch_code    =
+        if opts.include?(:branch_code)
+          opts[:branch_code]
+        elsif cleaned_bank_code.length > 3
+          cleaned_bank_code[3..-1]
+        end
+      account_number = opts[:account_number].rjust(16, '0')
+
+      {
+        bban:           [bank_code, branch_code, account_number].compact.join,
+        bank_code:      bank_code,
+        branch_code:    branch_code,
+        account_number: account_number
+      }
     end
 
-    def self.build_de_bban(opts)
+    def self.build_de_bban_info(opts)
       # Local account details format:
       #   bbbbbbbb aaaaaaaaaa
       #   Account number may be 1-10 digits long
@@ -123,13 +141,17 @@ module Ibandit
       #   Bundesbank, and handled by the GermanDetailsConverter class.
       converted_details = GermanDetailsConverter.convert(opts)
 
-      [
-        converted_details[:bank_code],
-        converted_details[:account_number].rjust(10, '0')
-      ].join
+      bank_code      = converted_details[:bank_code]
+      account_number = converted_details[:account_number].rjust(10, '0')
+
+      {
+        bban:           bank_code + account_number,
+        bank_code:      bank_code,
+        account_number: account_number
+      }
     end
 
-    def self.build_ee_bban(opts)
+    def self.build_ee_bban_info(opts)
       # Local account details format:
       #   bbaaaaaaaaaaax
       #   Account number may be up to 14 characters long
@@ -155,16 +177,23 @@ module Ibandit
       #   All Estonian payers should therefore know their IBAN.
       domestic_bank_code = opts[:account_number].gsub(/\A0+/, '').slice(0, 2)
 
-      case domestic_bank_code
-      when '11' then iban_bank_code = '22'
-      when '93' then iban_bank_code = '00'
-      else iban_bank_code = domestic_bank_code
-      end
+      iban_bank_code =
+        case domestic_bank_code
+        when '11' then '22'
+        when '93' then '00'
+        else domestic_bank_code
+        end
 
-      iban_bank_code + opts[:account_number].rjust(14, '0')
+      account_number = opts[:account_number].rjust(14, '0')
+
+      {
+        bban:           iban_bank_code + account_number,
+        bank_code:      iban_bank_code,
+        account_number: account_number
+      }
     end
 
-    def self.build_es_bban(opts)
+    def self.build_es_bban_info(opts)
       # Local account details format:
       #   bbbb-ssss-xx-aaaaaaaaaa
       #   Usually not separated, except by spaces or dashes
@@ -188,17 +217,26 @@ module Ibandit
       #   This method supports being passed the component IBAN parts, as defined
       #   by SWIFT, or a single 20 digit string.
       if opts.include?(:bank_code) && opts.include?(:branch_code)
-        [
-          opts[:bank_code],
-          opts[:branch_code],
-          opts[:account_number]
-        ].join
+        bank_code   = opts[:bank_code]
+        branch_code = opts[:branch_code]
+        account_number = opts[:account_number]
       else
-        opts[:account_number].tr('-', '')
+        cleaned_account_number = opts[:account_number].tr('-', '')
+
+        bank_code      = cleaned_account_number.slice(0, 4)
+        branch_code    = cleaned_account_number.slice(4, 4)
+        account_number = cleaned_account_number[8..-1]
       end
+
+      {
+        bban:           bank_code + branch_code + account_number,
+        bank_code:      bank_code,
+        branch_code:    branch_code,
+        account_number: account_number
+      }
     end
 
-    def self.build_fi_bban(opts)
+    def self.build_fi_bban_info(opts)
       # Local account details format:
       #   bbbbbb-aaaaaaax
       #   Usually two joined fields separated by a hyphen
@@ -216,18 +254,24 @@ module Ibandit
       #   Finnish account numbers need to be expanded into "electronic format"
       #   by adding zero-padding. The expansion method depends on the first
       #   character of the bank code.
-      if %w(4 5 6).include?(opts[:bank_code][0])
-        [
-          opts[:bank_code],
-          opts[:account_number][0],
-          opts[:account_number][1..-1].rjust(7, '0')
-        ].join
-      else
-        opts[:bank_code] + opts[:account_number].rjust(8, '0')
-      end
+      account_number =
+        if %w(4 5 6).include?(opts[:bank_code][0])
+          [
+            opts[:account_number][0],
+            opts[:account_number][1..-1].rjust(7, '0')
+          ].join
+        else
+          opts[:account_number].rjust(8, '0')
+        end
+
+      {
+        bban:           opts[:bank_code] + account_number,
+        bank_code:      opts[:bank_code],
+        account_number: account_number
+      }
     end
 
-    def self.build_fr_bban(opts)
+    def self.build_fr_bban_info(opts)
       # Local account details format:
       #   bbbbb-sssss-aaaaaaaaaaa-xx
       #   4 separated fields
@@ -248,14 +292,15 @@ module Ibandit
       #   digits when using this method.
       #
       # Padding: None
-      [
-        opts[:bank_code],
-        opts[:branch_code],
-        opts[:account_number]
-      ].join
+      {
+        bban:           opts[:bank_code] + opts[:branch_code] + opts[:account_number],
+        bank_code:      opts[:bank_code],
+        branch_code:    opts[:branch_code],
+        account_number: opts[:account_number]
+      }
     end
 
-    def self.build_gb_bban(opts)
+    def self.build_gb_bban_info(opts)
       # Local account details format:
       #   ssssss aaaaaaaa
       #   2 separated fields
@@ -282,45 +327,47 @@ module Ibandit
         bank_code = opts[:bank_code]
       else
         bic = Ibandit.find_bic('GB', branch_code)
-        raise BicNotFoundError, 'BIC finder failed to find a BIC.' if bic.nil?
-        bank_code = bic.slice(0, 4)
+        bank_code = bic.nil? ? nil : bic.slice(0, 4)
       end
 
-      [
-        bank_code,
-        branch_code,
-        opts[:account_number].gsub(/[-\s]/, '').rjust(8, '0')
-      ].join
+      account_number = opts[:account_number].gsub(/[-\s]/, '').rjust(8, '0')
+
+      {
+        bban:           [bank_code, branch_code, account_number].join,
+        bank_code:      bank_code,
+        branch_code:    branch_code,
+        account_number: account_number
+      }
     end
 
-    def self.build_lt_bban(opts)
+    def self.build_lt_bban_info(opts)
       # Additional info:
       #   Lithuanian national bank details were replaced with IBANs in 2004.
       #   All Lithuanian payers should therefore know their IBAN, and are
       #   unlikely to know how it breaks down. This method is included for
       #   consistency with the IBAN structure only.
-      [opts[:bank_code], opts[:account_number]].join
+      opts.merge(bban: opts[:bank_code] + opts[:account_number])
     end
 
-    def self.build_lu_bban(opts)
+    def self.build_lu_bban_info(opts)
       # Additional info:
       #   Luxembourgian national bank details were replaced with IBANs in 2002.
       #   All Luxembourgian payers should therefore know their IBAN, and are
       #   unlikely to know how it breaks down. This method is included for
       #   consistency with the IBAN structure only.
-      [opts[:bank_code], opts[:account_number]].join
+      opts.merge(bban: opts[:bank_code] + opts[:account_number])
     end
 
-    def self.build_lv_bban(opts)
+    def self.build_lv_bban_info(opts)
       # Additional info:
       #   Latvian national bank details were replaced with IBANs in 2004.
       #   All Latvian payers should therefore know their IBAN, and are
       #   unlikely to know how it breaks down. This method is included for
       #   consistency with the IBAN structure only.
-      [opts[:bank_code], opts[:account_number]].join
+      opts.merge(bban: opts[:bank_code] + opts[:account_number])
     end
 
-    def self.build_ie_bban(opts)
+    def self.build_ie_bban_info(opts)
       # Ireland uses the same BBAN construction method as the United Kingdom
       branch_code = opts[:branch_code].gsub(/[-\s]/, '')
 
@@ -328,18 +375,20 @@ module Ibandit
         bank_code = opts[:bank_code]
       else
         bic = Ibandit.find_bic('IE', branch_code)
-        raise BicNotFoundError, 'BIC finder failed to find a BIC.' if bic.nil?
-        bank_code = bic.slice(0, 4)
+        bank_code = bic.nil? ? nil : bic.slice(0, 4)
       end
 
-      [
-        bank_code,
-        branch_code,
-        opts[:account_number].gsub(/[-\s]/, '').rjust(8, '0')
-      ].join
+      account_number = opts[:account_number].gsub(/[-\s]/, '').rjust(8, '0')
+
+      {
+        bban:           [bank_code, branch_code, account_number].join,
+        bank_code:      bank_code,
+        branch_code:    branch_code,
+        account_number: account_number
+      }
     end
 
-    def self.build_it_bban(opts)
+    def self.build_it_bban_info(opts)
       # Local account details format:
       #   x/bbbbb/sssss/cccccccccccc
       #   4 fields, separated by slashes
@@ -359,23 +408,28 @@ module Ibandit
       #
       # Padding:
       #   Add leading zeros to account number if < 10 digits.
-      combined_code = [
-        opts[:bank_code],
-        opts[:branch_code],
-        opts[:account_number].rjust(12, '0')
-      ].join
+      bank_code      = opts[:bank_code]
+      branch_code    = opts[:branch_code]
+      account_number = opts[:account_number].rjust(12, '0')
 
-      check_digit = opts[:check_digit] || CheckDigit.italian(combined_code)
+      partial_bban = bank_code + branch_code + account_number
 
-      [check_digit, combined_code].join
+      check_digit = opts[:check_digit] || CheckDigit.italian(partial_bban)
+
+      {
+        bban:           check_digit + partial_bban,
+        bank_code:      bank_code,
+        branch_code:    branch_code,
+        account_number: account_number
+      }
     end
 
-    def self.build_mc_bban(opts)
+    def self.build_mc_bban_info(opts)
       # Monaco uses the same BBAN construction method as France
-      build_fr_bban(opts)
+      build_fr_bban_info(opts)
     end
 
-    def self.build_nl_bban(opts)
+    def self.build_nl_bban_info(opts)
       # Local account details format:
       #   aaaaaaaaaa
       #   1 field for account number only
@@ -393,13 +447,16 @@ module Ibandit
       #
       # Padding:
       #   Add leading zeros to account number if < 10 digits.
-      [
-        opts[:bank_code],
-        opts[:account_number].rjust(10, '0')
-      ].join
+      account_number = opts[:account_number].rjust(10, '0')
+
+      {
+        bban:           opts[:bank_code] + account_number,
+        bank_code:      opts[:bank_code],
+        account_number: account_number
+      }
     end
 
-    def self.build_pt_bban(opts)
+    def self.build_pt_bban_info(opts)
       # Local account details format:
       #   bbbb.ssss.ccccccccccc.xx
       #   Usually presented in one block
@@ -426,14 +483,14 @@ module Ibandit
       #   A side-effect of Portugal using the same algorithm for its local check
       #   digits as the overall IBAN check digits is that the overall digits are
       #   always 50.
-      [
+      opts.merge(bban: [
         opts[:bank_code],
         opts[:branch_code],
         opts[:account_number]
-      ].join
+      ].join)
     end
 
-    def self.build_si_bban(opts)
+    def self.build_si_bban_info(opts)
       # Local account details format:
       #   bbbbb-aaaaaaaaxx
       #   Two fields, separated by a dash
@@ -452,13 +509,16 @@ module Ibandit
       #   A side-effect of Slovenia using the same algorithm for its local check
       #   digits as the overall IBAN check digits is that the overall digits are
       #   always 56.
-      [
-        opts[:bank_code],
-        opts[:account_number].rjust(10, '0')
-      ].join
+      account_number = opts[:account_number].rjust(10, '0')
+
+      {
+        bban:           opts[:bank_code] + account_number,
+        bank_code:      opts[:bank_code],
+        account_number: account_number
+      }
     end
 
-    def self.build_sk_bban(opts)
+    def self.build_sk_bban_info(opts)
       # Local account details format:
       #   pppppp-aaaaaaaaaa/bbbb
       #   Three fields (or two, if prefix and account number are merged)
@@ -479,36 +539,34 @@ module Ibandit
       #   The SWIFT definition of a Slovakian IBAN includes both the account
       #   number prefix and the account number. This method therefore supports
       #   passing those fields concatenated.
-      if opts.include?(:account_number_prefix)
-        [
-          opts[:bank_code],
-          opts[:account_number_prefix].rjust(6, '0'),
-          opts[:account_number].rjust(10, '0')
-        ].join
-      else
-        [
-          opts[:bank_code],
+      account_number =
+        if opts.include?(:account_number_prefix)
+          [
+            opts[:account_number_prefix].rjust(6, '0'),
+            opts[:account_number].rjust(10, '0')
+          ].join
+        else
           opts[:account_number].tr('-', '').rjust(16, '0')
-        ].join
-      end
+        end
+
+      {
+        bban:           opts[:bank_code] + account_number,
+        bank_code:      opts[:bank_code],
+        account_number: account_number
+      }
     end
 
-    def self.build_sm_bban(opts)
+    def self.build_sm_bban_info(opts)
       # San Marino uses the same BBAN construction method as Italy
-      build_it_bban(opts)
+      build_it_bban_info(opts)
     end
 
     ##################
     # Helper methods #
     ##################
 
-    def self.require_fields(country_code, opts)
-      required_fields(country_code).each do |arg|
-        next if opts[arg]
-
-        msg = "#{arg} is a required field when building an #{country_code} IBAN"
-        raise ArgumentError, msg
-      end
+    def self.has_required_fields?(country_code, opts)
+      required_fields(country_code).all? { |argument| opts[argument] }
     end
 
     def self.required_fields(country_code)
@@ -526,14 +584,17 @@ module Ibandit
       end
     end
 
-    def self.build_iban(country_code, bban)
-      iban = [
-        country_code,
-        CheckDigit.iban(country_code, bban),
-        bban
-      ].join
+    def self.build_iban_parts(country_code, bban_info)
+      check_digits = CheckDigit.iban(country_code, bban_info[:bban])
 
-      IBAN.new(iban)
+      {
+        iban:           country_code + check_digits + bban_info[:bban],
+        country_code:   country_code,
+        check_digits:   check_digits,
+        bank_code:      bban_info[:bank_code],
+        branch_code:    bban_info[:branch_code],
+        account_number: bban_info[:account_number]
+      }
     end
   end
 end

--- a/lib/ibandit/iban_builder.rb
+++ b/lib/ibandit/iban_builder.rb
@@ -11,7 +11,7 @@ module Ibandit
       elsif !SUPPORTED_COUNTRY_CODES.include?(country_code)
         return opts
       else
-        return opts unless has_required_fields?(country_code, opts)
+        return opts unless fields_for?(country_code, opts)
         bban_info = send(:"build_#{country_code.downcase}_bban_info", opts)
         build_iban_parts(country_code, bban_info)
       end
@@ -293,9 +293,9 @@ module Ibandit
       #
       # Padding: None
       {
-        bban:           opts[:bank_code] + opts[:branch_code] + opts[:account_number],
-        bank_code:      opts[:bank_code],
-        branch_code:    opts[:branch_code],
+        bban: opts[:bank_code] + opts[:branch_code] + opts[:account_number],
+        bank_code: opts[:bank_code],
+        branch_code: opts[:branch_code],
         account_number: opts[:account_number]
       }
     end
@@ -565,7 +565,7 @@ module Ibandit
     # Helper methods #
     ##################
 
-    def self.has_required_fields?(country_code, opts)
+    def self.fields_for?(country_code, opts)
       required_fields(country_code).all? { |argument| opts[argument] }
     end
 

--- a/lib/ibandit/iban_splitter.rb
+++ b/lib/ibandit/iban_splitter.rb
@@ -1,0 +1,65 @@
+module Ibandit
+  class IBANSplitter
+    attr_reader :iban
+
+    def initialize(iban)
+      @iban = iban.to_s.gsub(/\s+/, '').upcase
+    end
+
+    def parts
+      {
+        iban:           iban,
+        country_code:   country_code,
+        check_digits:   check_digits,
+        bank_code:      bank_code,
+        branch_code:    branch_code,
+        account_number: account_number
+      }
+    end
+
+    ###################
+    # Component parts #
+    ###################
+
+    private
+
+    def country_code
+      iban[0, 2]
+    end
+
+    def check_digits
+      iban[2, 2] || ''
+    end
+
+    def bank_code
+      return '' unless structure
+
+      iban.slice(
+        structure[:bank_code_position] - 1,
+        structure[:bank_code_length]
+      ) || ''
+    end
+
+    def branch_code
+      return '' unless structure && structure[:branch_code_length] > 0
+
+      iban.slice(
+        structure[:branch_code_position] - 1,
+        structure[:branch_code_length]
+      ) || ''
+    end
+
+    def account_number
+      return '' unless structure
+
+      iban.slice(
+        structure[:account_number_position] - 1,
+        structure[:account_number_length]
+      ) || ''
+    end
+
+    def structure
+      Ibandit.structures[country_code]
+    end
+  end
+end

--- a/spec/ibandit/iban_builder_spec.rb
+++ b/spec/ibandit/iban_builder_spec.rb
@@ -80,7 +80,7 @@ describe Ibandit::IBANBuilder do
       context 'with dashes' do
         before { args[:account_number] = '510-0075470-61' }
         its([:iban]) { is_expected.to eq('BE62510007547061') }
-        its([:account_number]) { is_expected.to eq('510007547061')}
+        its([:account_number]) { is_expected.to eq('510007547061') }
       end
 
       context 'without an account_number' do

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -255,8 +255,12 @@ describe Ibandit::IBAN do
       specify { expect(iban).to receive(:valid_characters?).at_least(1) }
       specify { expect(iban).to receive(:valid_check_digits?).at_least(1) }
       specify { expect(iban).to receive(:valid_bank_code_length?).at_least(1) }
-      specify { expect(iban).to receive(:valid_branch_code_length?).at_least(1) }
-      specify { expect(iban).to receive(:valid_account_number_length?).at_least(1) }
+      specify do
+        expect(iban).to receive(:valid_branch_code_length?).at_least(1)
+      end
+      specify do
+        expect(iban).to receive(:valid_account_number_length?).at_least(1)
+      end
       specify { expect(iban).to receive(:valid_format?).at_least(1) }
     end
 

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -1,43 +1,33 @@
 require 'spec_helper'
 
 describe Ibandit::IBAN do
-  subject(:iban) { described_class.new(iban_code) }
+  subject(:iban) { described_class.new(args) }
+  let(:args) do
+    {
+      country_code:   country_code,
+      check_digits:   check_digits,
+      bank_code:      bank_code,
+      branch_code:    branch_code,
+      account_number: account_number
+    }
+  end
+  let(:country_code) { 'GB' }
+  let(:check_digits) { '82' }
+  let(:bank_code) { 'WEST' }
+  let(:branch_code) { '123456' }
+  let(:account_number) { '98765432' }
   let(:iban_code) { 'GB82WEST12345698765432' }
 
+  shared_context 'blank details', iban: :blank do
+    let(:country_code) { '' }
+    let(:check_digits) { '' }
+    let(:bank_code) { '' }
+    let(:branch_code) { '' }
+    let(:account_number) { '' }
+    let(:iban_code) { '' }
+  end
+
   its(:iban) { is_expected.to eq(iban_code) }
-
-  context 'with a poorly formatted IBAN' do
-    let(:iban_code) { "  gb82 WeSt 1234 5698 7654 32\n" }
-    its(:iban) { is_expected.to eq('GB82WEST12345698765432') }
-  end
-
-  context 'with nil' do
-    let(:iban_code) { nil }
-    its(:iban) { is_expected.to eq('') }
-  end
-
-  describe 'it decomposes the IBAN' do
-    its(:country_code) { is_expected.to eq('GB') }
-    its(:check_digits) { is_expected.to eq('82') }
-    its(:bank_code) { is_expected.to eq('WEST') }
-    its(:branch_code) { is_expected.to eq('123456') }
-    its(:account_number) { is_expected.to eq('98765432') }
-    its(:iban_national_id) { is_expected.to eq('WEST123456') }
-    its(:local_check_digits) { is_expected.to eq('') }
-
-    context 'when the IBAN is blank' do
-      let(:iban_code) { '' }
-
-      its(:country_code) { is_expected.to eq('') }
-      its(:check_digits) { is_expected.to eq('') }
-      its(:bank_code) { is_expected.to eq('') }
-      its(:branch_code) { is_expected.to eq('') }
-      its(:account_number) { is_expected.to eq('') }
-      its(:iban_national_id) { is_expected.to eq('') }
-      its(:bban) { is_expected.to eq('') }
-      its(:local_check_digits) { is_expected.to eq('') }
-    end
-  end
 
   describe '#to_s' do
     specify { expect(iban.to_s).to eq('GB82WEST12345698765432') }
@@ -62,7 +52,7 @@ describe Ibandit::IBAN do
     end
 
     context 'with an unknown country code' do
-      let(:iban_code) { 'AA123456789123456' }
+      let(:country_code) { 'AA' }
       it { is_expected.to eq(false) }
 
       it 'sets errors on the IBAN' do
@@ -76,17 +66,17 @@ describe Ibandit::IBAN do
     subject { iban.valid_check_digits? }
 
     context 'with valid details' do
-      let(:iban_code) { 'GB82WEST12345698765432' }
       it { is_expected.to eq(true) }
 
       context 'where the check digit is zero-padded' do
-        let(:iban_code) { 'GB06WEST12345698765442' }
+        let(:check_digits) { '06' }
+        let(:account_number) { '98765442' }
         it { is_expected.to eq(true) }
       end
     end
 
     context 'with invalid details' do
-      let(:iban_code) { 'GB12WEST12345698765432' }
+      let(:args) { 'GB12WEST12345698765432' }
       it { is_expected.to eq(false) }
 
       it 'sets errors on the IBAN' do
@@ -96,7 +86,7 @@ describe Ibandit::IBAN do
     end
 
     context 'with invalid characters' do
-      let(:iban_code) { 'AA82-EST123456987654' }
+      let(:args) { 'GB82-EST12345698765432' }
       it { is_expected.to be_nil }
 
       it 'does not set errors on the IBAN' do
@@ -105,8 +95,7 @@ describe Ibandit::IBAN do
       end
     end
 
-    context 'with an empty IBAN' do
-      let(:iban_code) { '' }
+    context 'with an empty IBAN', iban: :blank do
       it { is_expected.to be_nil }
 
       it 'does not set errors on the IBAN' do
@@ -116,31 +105,96 @@ describe Ibandit::IBAN do
     end
   end
 
-  describe '#valid_length?' do
-    subject { iban.valid_length? }
+  describe '#valid_bank_code_length?' do
+    subject { iban.valid_bank_code_length? }
 
     context 'with valid details' do
-      let(:iban_code) { 'GB82WEST12345698765432' }
       it { is_expected.to eq(true) }
     end
 
     context 'with invalid details' do
-      let(:iban_code) { 'GB82WEST123456987654' }
+      let(:bank_code) { 'WES' }
       it { is_expected.to eq(false) }
 
       it 'sets errors on the IBAN' do
-        iban.valid_length?
-        expect(iban.errors).to include(:length)
+        iban.valid_bank_code_length?
+        expect(iban.errors).to include(:bank_code)
       end
     end
 
     context 'with an invalid country_code' do
-      let(:iban_code) { 'AA82WEST123456987654' }
+      let(:country_code) { 'AA' }
       it { is_expected.to be_nil }
 
       it 'does not set errors on the IBAN' do
-        iban.valid_length?
-        expect(iban.errors).to_not include(:length)
+        iban.valid_bank_code_length?
+        expect(iban.errors).to_not include(:bank_code)
+      end
+    end
+  end
+
+  describe '#valid_branch_code_length?' do
+    subject { iban.valid_branch_code_length? }
+
+    context 'with valid details' do
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with invalid details' do
+      let(:branch_code) { '12345' }
+      it { is_expected.to eq(false) }
+
+      it 'sets errors on the IBAN' do
+        iban.valid_branch_code_length?
+        expect(iban.errors).to include(:branch_code)
+      end
+    end
+
+    context 'without a branch code' do
+      let(:branch_code) { nil }
+      it { is_expected.to eq(false) }
+
+      it 'sets errors on the IBAN' do
+        iban.valid_branch_code_length?
+        expect(iban.errors).to include(:branch_code)
+      end
+    end
+
+    context 'with an invalid country_code' do
+      let(:country_code) { 'AA' }
+      it { is_expected.to be_nil }
+
+      it 'does not set errors on the IBAN' do
+        iban.valid_branch_code_length?
+        expect(iban.errors).to_not include(:branch_code)
+      end
+    end
+  end
+
+  describe '#valid_account_number_length?' do
+    subject { iban.valid_account_number_length? }
+
+    context 'with valid details' do
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with invalid details' do
+      let(:args) { 'GB82WEST123456987654' }
+      it { is_expected.to eq(false) }
+
+      it 'sets errors on the IBAN' do
+        iban.valid_account_number_length?
+        expect(iban.errors).to include(:account_number)
+      end
+    end
+
+    context 'with an invalid country_code' do
+      let(:country_code) { 'AA' }
+      it { is_expected.to be_nil }
+
+      it 'does not set errors on the IBAN' do
+        iban.valid_account_number_length?
+        expect(iban.errors).to_not include(:account_number)
       end
     end
   end
@@ -149,12 +203,12 @@ describe Ibandit::IBAN do
     subject { iban.valid_characters? }
 
     context 'with valid details' do
-      let(:iban_code) { 'GB82WEST12345698765432' }
+      let(:args) { 'GB82WEST12345698765432' }
       it { is_expected.to eq(true) }
     end
 
     context 'with invalid details' do
-      let(:iban_code) { 'GB-123ABCD' }
+      let(:args) { 'GB-123ABCD' }
       it { is_expected.to eq(false) }
 
       it 'sets errors on the IBAN' do
@@ -168,12 +222,12 @@ describe Ibandit::IBAN do
     subject { iban.valid_format? }
 
     context 'with valid details' do
-      let(:iban_code) { 'GB82WEST12345698765432' }
+      let(:args) { 'GB82WEST12345698765432' }
       it { is_expected.to eq(true) }
     end
 
     context 'with invalid details' do
-      let(:iban_code) { 'GB82WEST12AAAAAA7654' }
+      let(:args) { 'GB82WEST12AAAAAA7654' }
       it { is_expected.to eq(false) }
 
       it 'sets errors on the IBAN' do
@@ -183,7 +237,7 @@ describe Ibandit::IBAN do
     end
 
     context 'with an invalid country_code' do
-      let(:iban_code) { 'AA82WEST12AAAAAA7654' }
+      let(:args) { 'AA82WEST12AAAAAA7654' }
       it { is_expected.to be_nil }
 
       it 'does not set errors on the IBAN' do
@@ -200,349 +254,351 @@ describe Ibandit::IBAN do
       specify { expect(iban).to receive(:valid_country_code?).at_least(1) }
       specify { expect(iban).to receive(:valid_characters?).at_least(1) }
       specify { expect(iban).to receive(:valid_check_digits?).at_least(1) }
-      specify { expect(iban).to receive(:valid_length?).at_least(1) }
+      specify { expect(iban).to receive(:valid_bank_code_length?).at_least(1) }
+      specify { expect(iban).to receive(:valid_branch_code_length?).at_least(1) }
+      specify { expect(iban).to receive(:valid_account_number_length?).at_least(1) }
       specify { expect(iban).to receive(:valid_format?).at_least(1) }
     end
 
     context 'for a valid Albanian IBAN' do
-      let(:iban_code) { 'AL47 2121 1009 0000 0002 3569 8741' }
+      let(:args) { 'AL47 2121 1009 0000 0002 3569 8741' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Andorran IBAN' do
-      let(:iban_code) { 'AD12 0001 2030 2003 5910 0100' }
+      let(:args) { 'AD12 0001 2030 2003 5910 0100' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Austrian IBAN' do
-      let(:iban_code) { 'AT61 1904 3002 3457 3201' }
+      let(:args) { 'AT61 1904 3002 3457 3201' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Azerbaijanian IBAN' do
-      let(:iban_code) { 'AZ21 NABZ 0000 0000 1370 1000 1944' }
+      let(:args) { 'AZ21 NABZ 0000 0000 1370 1000 1944' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Bahrainian IBAN' do
-      let(:iban_code) { 'BH67 BMAG 0000 1299 1234 56' }
+      let(:args) { 'BH67 BMAG 0000 1299 1234 56' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Belgian IBAN' do
-      let(:iban_code) { 'BE62 5100 0754 7061' }
+      let(:args) { 'BE62 5100 0754 7061' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Bosnian IBAN' do
-      let(:iban_code) { 'BA39 1290 0794 0102 8494' }
+      let(:args) { 'BA39 1290 0794 0102 8494' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Bulgarian IBAN' do
-      let(:iban_code) { 'BG80 BNBG 9661 1020 3456 78' }
+      let(:args) { 'BG80 BNBG 9661 1020 3456 78' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Croatian IBAN' do
-      let(:iban_code) { 'HR12 1001 0051 8630 0016 0' }
+      let(:args) { 'HR12 1001 0051 8630 0016 0' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Cypriot IBAN' do
-      let(:iban_code) { 'CY17 0020 0128 0000 0012 0052 7600' }
+      let(:args) { 'CY17 0020 0128 0000 0012 0052 7600' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Czech IBAN' do
-      let(:iban_code) { 'CZ65 0800 0000 1920 0014 5399' }
+      let(:args) { 'CZ65 0800 0000 1920 0014 5399' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Danish IBAN' do
-      let(:iban_code) { 'DK50 0040 0440 1162 43' }
+      let(:args) { 'DK50 0040 0440 1162 43' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Estonian IBAN' do
-      let(:iban_code) { 'EE38 2200 2210 2014 5685' }
+      let(:args) { 'EE38 2200 2210 2014 5685' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Faroe Islands IBAN' do
-      let(:iban_code) { 'FO97 5432 0388 8999 44' }
+      let(:args) { 'FO97 5432 0388 8999 44' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Finnish IBAN' do
-      let(:iban_code) { 'FI21 1234 5600 0007 85' }
+      let(:args) { 'FI21 1234 5600 0007 85' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid French IBAN' do
-      let(:iban_code) { 'FR14 2004 1010 0505 0001 3M02 606' }
+      let(:args) { 'FR14 2004 1010 0505 0001 3M02 606' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Georgian IBAN' do
-      let(:iban_code) { 'GE29 NB00 0000 0101 9049 17' }
+      let(:args) { 'GE29 NB00 0000 0101 9049 17' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid German IBAN' do
-      let(:iban_code) { 'DE89 3704 0044 0532 0130 00' }
+      let(:args) { 'DE89 3704 0044 0532 0130 00' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Gibraltan IBAN' do
-      let(:iban_code) { 'GI75 NWBK 0000 0000 7099 453' }
+      let(:args) { 'GI75 NWBK 0000 0000 7099 453' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Greek IBAN' do
-      let(:iban_code) { 'GR16 0110 1250 0000 0001 2300 695' }
+      let(:args) { 'GR16 0110 1250 0000 0001 2300 695' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Greenland IBAN' do
-      let(:iban_code) { 'GL56 0444 9876 5432 10' }
+      let(:args) { 'GL56 0444 9876 5432 10' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Hungarian IBAN' do
-      let(:iban_code) { 'HU42 1177 3016 1111 1018 0000 0000' }
+      let(:args) { 'HU42 1177 3016 1111 1018 0000 0000' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Icelandic IBAN' do
-      let(:iban_code) { 'IS14 0159 2600 7654 5510 7303 39' }
+      let(:args) { 'IS14 0159 2600 7654 5510 7303 39' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Irish IBAN' do
-      let(:iban_code) { 'IE29 AIBK 9311 5212 3456 78' }
+      let(:args) { 'IE29 AIBK 9311 5212 3456 78' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Israeli IBAN' do
-      let(:iban_code) { 'IL62 0108 0000 0009 9999 999' }
+      let(:args) { 'IL62 0108 0000 0009 9999 999' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Italian IBAN' do
-      let(:iban_code) { 'IT40 S054 2811 1010 0000 0123 456' }
+      let(:args) { 'IT40 S054 2811 1010 0000 0123 456' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Jordanian IBAN' do
-      let(:iban_code) { 'JO94 CBJO 0010 0000 0000 0131 0003 02' }
+      let(:args) { 'JO94 CBJO 0010 0000 0000 0131 0003 02' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Kuwaiti IBAN' do
-      let(:iban_code) { 'KW81 CBKU 0000 0000 0000 1234 5601 01' }
+      let(:args) { 'KW81 CBKU 0000 0000 0000 1234 5601 01' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Latvian IBAN' do
-      let(:iban_code) { 'LV80 BANK 0000 4351 9500 1' }
+      let(:args) { 'LV80 BANK 0000 4351 9500 1' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Lebanese IBAN' do
-      let(:iban_code) { 'LB62 0999 0000 0001 0019 0122 9114' }
+      let(:args) { 'LB62 0999 0000 0001 0019 0122 9114' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Liechtensteinian IBAN' do
-      let(:iban_code) { 'LI21 0881 0000 2324 013A A' }
+      let(:args) { 'LI21 0881 0000 2324 013A A' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Lithuanian IBAN' do
-      let(:iban_code) { 'LT12 1000 0111 0100 1000' }
+      let(:args) { 'LT12 1000 0111 0100 1000' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Luxembourgian IBAN' do
-      let(:iban_code) { 'LU28 0019 4006 4475 0000' }
+      let(:args) { 'LU28 0019 4006 4475 0000' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Macedonian IBAN' do
-      let(:iban_code) { 'MK072 5012 0000 0589 84' }
+      let(:args) { 'MK072 5012 0000 0589 84' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Maltese IBAN' do
-      let(:iban_code) { 'MT84 MALT 0110 0001 2345 MTLC AST0 01S' }
+      let(:args) { 'MT84 MALT 0110 0001 2345 MTLC AST0 01S' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Maurititanian IBAN' do
-      let(:iban_code) { 'MU17 BOMM 0101 1010 3030 0200 000M UR' }
+      let(:args) { 'MU17 BOMM 0101 1010 3030 0200 000M UR' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Moldovan IBAN' do
-      let(:iban_code) { 'MD24 AG00 0225 1000 1310 4168' }
+      let(:args) { 'MD24 AG00 0225 1000 1310 4168' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Monocan IBAN' do
-      let(:iban_code) { 'MC93 2005 2222 1001 1223 3M44 555' }
+      let(:args) { 'MC93 2005 2222 1001 1223 3M44 555' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Montenegrian IBAN' do
-      let(:iban_code) { 'ME25 5050 0001 2345 6789 51' }
+      let(:args) { 'ME25 5050 0001 2345 6789 51' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Dutch IBAN' do
-      let(:iban_code) { 'NL39 RABO 0300 0652 64' }
+      let(:args) { 'NL39 RABO 0300 0652 64' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Norwegian IBAN' do
-      let(:iban_code) { 'NO93 8601 1117 947' }
+      let(:args) { 'NO93 8601 1117 947' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Pakistani IBAN' do
-      let(:iban_code) { 'PK36 SCBL 0000 0011 2345 6702' }
+      let(:args) { 'PK36 SCBL 0000 0011 2345 6702' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Polish IBAN' do
-      let(:iban_code) { 'PL60 1020 1026 0000 0422 7020 1111' }
+      let(:args) { 'PL60 1020 1026 0000 0422 7020 1111' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Potuguese IBAN' do
-      let(:iban_code) { 'PT50 0002 0123 1234 5678 9015 4' }
+      let(:args) { 'PT50 0002 0123 1234 5678 9015 4' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Qatari IBAN' do
-      let(:iban_code) { 'QA58 DOHB 0000 1234 5678 90AB CDEF G' }
+      let(:args) { 'QA58 DOHB 0000 1234 5678 90AB CDEF G' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Romanian IBAN' do
-      let(:iban_code) { 'RO49 AAAA 1B31 0075 9384 0000' }
+      let(:args) { 'RO49 AAAA 1B31 0075 9384 0000' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid San Marinian IBAN' do
-      let(:iban_code) { 'SM86 U032 2509 8000 0000 0270 100' }
+      let(:args) { 'SM86 U032 2509 8000 0000 0270 100' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Saudi IBAN' do
-      let(:iban_code) { 'SA03 8000 0000 6080 1016 7519' }
+      let(:args) { 'SA03 8000 0000 6080 1016 7519' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Serbian IBAN' do
-      let(:iban_code) { 'RS35 2600 0560 1001 6113 79' }
+      let(:args) { 'RS35 2600 0560 1001 6113 79' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Slovakian IBAN' do
-      let(:iban_code) { 'SK31 1200 0000 1987 4263 7541' }
+      let(:args) { 'SK31 1200 0000 1987 4263 7541' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Slovenian IBAN' do
-      let(:iban_code) { 'SI56 1910 0000 0123 438' }
+      let(:args) { 'SI56 1910 0000 0123 438' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Spanish IBAN' do
-      let(:iban_code) { 'ES80 2310 0001 1800 0001 2345' }
+      let(:args) { 'ES80 2310 0001 1800 0001 2345' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Swedish IBAN' do
-      let(:iban_code) { 'SE35 5000 0000 0549 1000 0003' }
+      let(:args) { 'SE35 5000 0000 0549 1000 0003' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Swiss IBAN' do
-      let(:iban_code) { 'CH93 0076 2011 6238 5295 7' }
+      let(:args) { 'CH93 0076 2011 6238 5295 7' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Tunisian IBAN' do
-      let(:iban_code) { 'TN59 1000 6035 1835 9847 8831' }
+      let(:args) { 'TN59 1000 6035 1835 9847 8831' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid Turkish IBAN' do
-      let(:iban_code) { 'TR33 0006 1005 1978 6457 8413 26' }
+      let(:args) { 'TR33 0006 1005 1978 6457 8413 26' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid UAE IBAN' do
-      let(:iban_code) { 'AE07 0331 2345 6789 0123 456' }
+      let(:args) { 'AE07 0331 2345 6789 0123 456' }
       it { is_expected.to be_valid }
     end
 
     context 'for a valid UK IBAN' do
-      let(:iban_code) { 'GB82 WEST 1234 5698 7654 32' }
+      let(:args) { 'GB82 WEST 1234 5698 7654 32' }
       it { is_expected.to be_valid }
     end
   end
 
   describe '#local_check_digits' do
     context 'with a Belgian IBAN' do
-      let(:iban_code) { 'BE62510007547061' }
+      let(:args) { 'BE62510007547061' }
       its(:local_check_digits) { is_expected.to eq('61') }
     end
 
     context 'with a French IBAN' do
-      let(:iban_code) { 'FR1234567890123456789012345' }
+      let(:args) { 'FR1234567890123456789012345' }
       its(:local_check_digits) { is_expected.to eq('45') }
     end
 
     context 'with a Monocan IBAN' do
-      let(:iban_code) { 'MC9320052222100112233M44555' }
+      let(:args) { 'MC9320052222100112233M44555' }
       its(:local_check_digits) { is_expected.to eq('55') }
     end
 
     context 'with a Spanish IBAN' do
-      let(:iban_code) { 'ES1212345678911234567890' }
+      let(:args) { 'ES1212345678911234567890' }
       its(:local_check_digits) { is_expected.to eq('91') }
     end
 
     context 'with an Italian IBAN' do
-      let(:iban_code) { 'IT12A1234567890123456789012' }
+      let(:args) { 'IT12A1234567890123456789012' }
       its(:local_check_digits) { is_expected.to eq('A') }
     end
 
     context 'with an Estonian IBAN' do
-      let(:iban_code) { 'EE382200221020145685' }
+      let(:args) { 'EE382200221020145685' }
       its(:local_check_digits) { is_expected.to eq('5') }
     end
 
     context 'with an Finnish IBAN' do
-      let(:iban_code) { 'FI2112345600000785' }
+      let(:args) { 'FI2112345600000785' }
       its(:local_check_digits) { is_expected.to eq('5') }
     end
 
     context 'with an Portuguese IBAN' do
-      let(:iban_code) { 'PT50000201231234567890154' }
+      let(:args) { 'PT50000201231234567890154' }
       its(:local_check_digits) { is_expected.to eq('54') }
     end
 
     context 'with a Slovakian IBAN' do
-      let(:iban_code) { 'SK3112000000198742637541' }
+      let(:args) { 'SK3112000000198742637541' }
       its(:local_check_digits) { is_expected.to eq('9') }
     end
 
     context 'with a Dutch IBAN' do
-      let(:iban_code) { 'NL91ABNA0417164300' }
+      let(:args) { 'NL91ABNA0417164300' }
       its(:local_check_digits) { is_expected.to eq('0') }
     end
   end

--- a/spec/ibandit/iban_splitter_spec.rb
+++ b/spec/ibandit/iban_splitter_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Ibandit::IBANSplitter do
+  subject(:parts) { described_class.new(iban_code).parts }
+
+  context 'with a poorly formatted IBAN' do
+    let(:iban_code) { "  gb82 WeSt 1234 5698 7654 32\n" }
+    its([:iban]) { is_expected.to eq('GB82WEST12345698765432') }
+    its([:country_code]) { is_expected.to eq('GB') }
+    its([:check_digits]) { is_expected.to eq('82') }
+    its([:bank_code]) { is_expected.to eq('WEST') }
+    its([:branch_code]) { is_expected.to eq('123456') }
+    its([:account_number]) { is_expected.to eq('98765432') }
+  end
+
+  context 'with nil' do
+    let(:iban_code) { nil }
+    its([:iban]) { is_expected.to eq('') }
+    its([:country_code]) { is_expected.to eq('') }
+    its([:check_digits]) { is_expected.to eq('') }
+    its([:bank_code]) { is_expected.to eq('') }
+    its([:branch_code]) { is_expected.to eq('') }
+    its([:account_number]) { is_expected.to eq('') }
+  end
+
+  describe 'with an empty string' do
+    let(:iban_code) { '' }
+    its([:iban]) { is_expected.to eq('') }
+    its([:country_code]) { is_expected.to eq('') }
+    its([:check_digits]) { is_expected.to eq('') }
+    its([:bank_code]) { is_expected.to eq('') }
+    its([:branch_code]) { is_expected.to eq('') }
+    its([:account_number]) { is_expected.to eq('') }
+  end
+end


### PR DESCRIPTION
This a pretty massive refactor:
- `IBAN.new` now calls either `IBANSplitter` (if you give it a string), or `IBANBuilder` (if you give it a hash)
- Both convert the input into a hash containing `iban`, `country_code`, `check_digits`, `bank_code`, `branch_code`, `account_number`
- `IBAN` validates these things (checks for bad characters, country code, check digits, component lengths, format)

Wins:
- Can tell the user whether their `bank_code` or `account_number` was too short, rather than the whole thing
- Don't have to call `IBANBuilder` separately to build from national details