### PR TITLE
Better cleaning

### DIFF
--- a/lib/ibandit.rb
+++ b/lib/ibandit.rb
@@ -4,6 +4,7 @@ require 'ibandit/iban'
 require 'ibandit/german_details_converter'
 require 'ibandit/iban_splitter'
 require 'ibandit/iban_assembler'
+require 'ibandit/local_details_cleaner'
 require 'ibandit/check_digit'
 
 module Ibandit

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -45,6 +45,7 @@ module Ibandit
     ##########################
 
     def self.clean_at_details(local_details)
+      return {} unless local_details[:account_number].length >= 4
       {
         bank_code: local_details[:bank_code],
         account_number: local_details[:account_number].rjust(11, '0')
@@ -65,7 +66,12 @@ module Ibandit
         elsif cleaned_bank_code.length > 3
           cleaned_bank_code[3..-1]
         end
-      account_number = local_details[:account_number].rjust(16, '0')
+      account_number =
+        if local_details[:account_number].length >= 7
+          local_details[:account_number].rjust(16, '0')
+        else
+          local_details[:account_number]
+        end
 
       {
         bank_code:      bank_code,
@@ -76,6 +82,8 @@ module Ibandit
 
     def self.clean_de_details(local_details)
       converted_details = GermanDetailsConverter.convert(local_details)
+
+      return {} unless converted_details[:account_number].length >= 4
 
       {
         bank_code:      converted_details[:bank_code],
@@ -154,8 +162,8 @@ module Ibandit
         bank_code = bic.nil? ? nil : bic.slice(0, 4)
       end
 
-      account_number =
-        local_details[:account_number].gsub(/[-\s]/, '').rjust(8, '0')
+      account_number = local_details[:account_number].gsub(/[-\s]/, '')
+      account_number = account_number.rjust(8, '0') if account_number.length > 5
 
       {
         bank_code:      bank_code,
@@ -186,8 +194,8 @@ module Ibandit
         bank_code = bic.nil? ? nil : bic.slice(0, 4)
       end
 
-      account_number =
-        local_details[:account_number].gsub(/[-\s]/, '').rjust(8, '0')
+      account_number = local_details[:account_number].gsub(/[-\s]/, '')
+      account_number = account_number.rjust(8, '0') if account_number.length > 5
 
       {
         bank_code:      bank_code,

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -1,0 +1,250 @@
+module Ibandit
+  module LocalDetailsCleaner
+    SUPPORTED_COUNTRY_CODES = %w(AT BE CY DE EE ES FI FR GB IE IT LT LU LV MC NL
+                                 PT SI SK SM).freeze
+
+    def self.clean(local_details)
+      country_code = local_details[:country_code]
+
+      return local_details unless can_clean?(country_code, local_details)
+
+      local_details.merge(
+        public_send(:"clean_#{country_code.downcase}_details", local_details))
+    end
+
+    ###########
+    # Helpers #
+    ###########
+
+    def self.can_clean?(country_code, local_details)
+      SUPPORTED_COUNTRY_CODES.include?(country_code) &&
+        fields_for?(country_code, local_details)
+    end
+
+    def self.fields_for?(country_code, opts)
+      required_fields(country_code).all? { |argument| opts[argument] }
+    end
+
+    def self.required_fields(country_code)
+      case country_code
+      when 'AT', 'CY', 'DE', 'FI', 'LT', 'LU', 'LV', 'NL', 'SI', 'SK'
+        %i(bank_code account_number)
+      when 'BE', 'EE', 'ES'
+        %i(account_number)
+      when 'GB', 'IE'
+        if Ibandit.bic_finder.nil? then %i(bank_code branch_code account_number)
+        else %i(branch_code account_number)
+        end
+      else
+        %i(bank_code branch_code account_number)
+      end
+    end
+
+    ##########################
+    # Country-specific logic #
+    ##########################
+
+    def self.clean_at_details(local_details)
+      {
+        bank_code: local_details[:bank_code],
+        account_number: local_details[:account_number].rjust(11, '0')
+      }
+    end
+
+    def self.clean_be_details(local_details)
+      { account_number: local_details[:account_number].tr('-', '') }
+    end
+
+    def self.clean_cy_details(local_details)
+      cleaned_bank_code = local_details[:bank_code].gsub(/[-\s]/, '')
+
+      bank_code      = cleaned_bank_code.slice(0, 3)
+      branch_code    =
+        if local_details[:branch_code]
+          local_details[:branch_code]
+        elsif cleaned_bank_code.length > 3
+          cleaned_bank_code[3..-1]
+        end
+      account_number = local_details[:account_number].rjust(16, '0')
+
+      {
+        bank_code:      bank_code,
+        branch_code:    branch_code,
+        account_number: account_number
+      }
+    end
+
+    def self.clean_de_details(local_details)
+      converted_details = GermanDetailsConverter.convert(local_details)
+
+      {
+        bank_code:      converted_details[:bank_code],
+        account_number: converted_details[:account_number].rjust(10, '0')
+      }
+    end
+
+    def self.clean_ee_details(local_details)
+      domestic_bank_code =
+        local_details[:account_number].gsub(/\A0+/, '').slice(0, 2)
+
+      iban_bank_code =
+        case domestic_bank_code
+        when '11' then '22'
+        when '93' then '00'
+        else domestic_bank_code
+        end
+
+      account_number = local_details[:account_number].rjust(14, '0')
+
+      { bank_code: iban_bank_code, account_number: account_number }
+    end
+
+    def self.clean_es_details(local_details)
+      if local_details[:bank_code] && local_details[:branch_code]
+        bank_code      = local_details[:bank_code]
+        branch_code    = local_details[:branch_code]
+        account_number = local_details[:account_number]
+      else
+        cleaned_account_number = local_details[:account_number].tr('-', '')
+
+        bank_code      = cleaned_account_number.slice(0, 4)
+        branch_code    = cleaned_account_number.slice(4, 4)
+        account_number = cleaned_account_number[8..-1]
+      end
+
+      {
+        bank_code:      bank_code,
+        branch_code:    branch_code,
+        account_number: account_number
+      }
+    end
+
+    def self.clean_fi_details(local_details)
+      account_number =
+        if %w(4 5 6).include?(local_details[:bank_code][0])
+          [
+            local_details[:account_number][0],
+            local_details[:account_number][1..-1].rjust(7, '0')
+          ].join
+        else
+          local_details[:account_number].rjust(8, '0')
+        end
+
+      {
+        bank_code:      local_details[:bank_code],
+        account_number: account_number
+      }
+    end
+
+    def self.clean_fr_details(local_details)
+      {
+        bank_code:      local_details[:bank_code],
+        branch_code:    local_details[:branch_code],
+        account_number: local_details[:account_number].gsub(/[-\s]/, '')
+      }
+    end
+
+    def self.clean_gb_details(local_details)
+      branch_code = local_details[:branch_code].gsub(/[-\s]/, '')
+
+      if local_details[:bank_code]
+        bank_code = local_details[:bank_code]
+      else
+        bic = Ibandit.find_bic('GB', branch_code)
+        bank_code = bic.nil? ? nil : bic.slice(0, 4)
+      end
+
+      account_number =
+        local_details[:account_number].gsub(/[-\s]/, '').rjust(8, '0')
+
+      {
+        bank_code:      bank_code,
+        branch_code:    branch_code,
+        account_number: account_number
+      }
+    end
+
+    def self.clean_lt_details(local_details)
+      local_details
+    end
+
+    def self.clean_lu_details(local_details)
+      local_details
+    end
+
+    def self.clean_lv_details(local_details)
+      local_details
+    end
+
+    def self.clean_ie_details(local_details)
+      branch_code = local_details[:branch_code].gsub(/[-\s]/, '')
+
+      if local_details[:bank_code]
+        bank_code = local_details[:bank_code]
+      else
+        bic = Ibandit.find_bic('IE', branch_code)
+        bank_code = bic.nil? ? nil : bic.slice(0, 4)
+      end
+
+      account_number =
+        local_details[:account_number].gsub(/[-\s]/, '').rjust(8, '0')
+
+      {
+        bank_code:      bank_code,
+        branch_code:    branch_code,
+        account_number: account_number
+      }
+    end
+
+    def self.clean_it_details(local_details)
+      {
+        bank_code:      local_details[:bank_code],
+        branch_code:    local_details[:branch_code],
+        account_number: local_details[:account_number].rjust(12, '0')
+      }
+    end
+
+    def self.clean_mc_details(local_details)
+      clean_fr_details(local_details)
+    end
+
+    def self.clean_nl_details(local_details)
+      {
+        bank_code:      local_details[:bank_code],
+        account_number: local_details[:account_number].rjust(10, '0')
+      }
+    end
+
+    def self.clean_pt_details(local_details)
+      local_details
+    end
+
+    def self.clean_si_details(local_details)
+      {
+        bank_code:      local_details[:bank_code],
+        account_number: local_details[:account_number].rjust(10, '0')
+      }
+    end
+
+    def self.clean_sk_details(local_details)
+      account_number =
+        if local_details.include?(:account_number_prefix)
+          [
+            local_details[:account_number_prefix].rjust(6, '0'),
+            local_details[:account_number].rjust(10, '0')
+          ].join
+        else
+          local_details[:account_number].tr('-', '').rjust(16, '0')
+        end
+
+      {
+        bank_code:      local_details[:bank_code],
+        account_number: account_number
+      }
+    end
+
+    def self.clean_sm_details(local_details)
+      clean_it_details(local_details)
+    end
+  end
+end

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -1,0 +1,652 @@
+require 'spec_helper'
+
+describe Ibandit::LocalDetailsCleaner do
+  subject(:cleaned) { described_class.clean(local_details) }
+  let(:local_details) do
+    {
+      country_code:   country_code,
+      bank_code:      bank_code,
+      branch_code:    branch_code,
+      account_number: account_number
+    }
+  end
+  let(:country_code) { nil }
+  let(:bank_code) { nil }
+  let(:branch_code) { nil }
+  let(:account_number) { nil }
+
+  context 'without country code' do
+    it { is_expected.to eq(local_details) }
+  end
+
+  context 'with an unsupported country code' do
+    let(:country_code) { 'FU' }
+    it { is_expected.to eq(local_details) }
+  end
+
+  context 'Austria' do
+    let(:country_code) { 'AT' }
+    let(:bank_code) { '19043' }
+    let(:account_number) { '00234573201' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with an account number which needs zero-padding' do
+      let(:account_number) { '234573201' }
+      its([:account_number]) { is_expected.to eq('00234573201') }
+    end
+
+    context 'with a long account number' do
+      let(:account_number) { '234573201999' }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'with a short bank code' do
+      let(:bank_code) { '1904' }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'with a long bank code' do
+      let(:bank_code) { '190430' }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'Belgium' do
+    let(:country_code) { 'BE' }
+    let(:account_number) { '510007547061' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with dashes' do
+      let(:account_number) { '510-0075470-61' }
+      its([:account_number]) { is_expected.to eq('510007547061') }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'Cyprus' do
+    let(:country_code) { 'CY' }
+    let(:account_number) { '0000001200527600' }
+    let(:bank_code) { '002' }
+    let(:branch_code) { '00128' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with a short account number' do
+      let(:account_number) { '1200527600' }
+      its([:account_number]) { is_expected.to eq('0000001200527600') }
+    end
+
+    context 'with a long account number' do
+      let(:account_number) { '00000001200527600' }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'with the branch code in the bank code field' do
+      let(:bank_code) { '002 00128' }
+      let(:branch_code) { nil }
+      its([:bank_code]) { is_expected.to eq('002') }
+      its([:branch_code]) { is_expected.to eq('00128') }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'Germany' do
+    let(:country_code) { 'DE' }
+    let(:bank_code) { '37040044' }
+    let(:account_number) { '0532013000' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'with a pseudo account number' do
+      let(:bank_code) { '37080040' }
+      let(:account_number) { '111' }
+      its([:bank_code]) { is_expected.to eq(bank_code) }
+      its([:account_number]) { is_expected.to eq('0215022000') }
+    end
+  end
+
+  context 'Estonia' do
+    let(:country_code) { 'EE' }
+    let(:account_number) { '0221020145685' }
+
+    its([:bank_code]) { is_expected.to eq('22') }
+    its([:account_number]) { is_expected.to eq('00221020145685') }
+
+    context 'with an account number that needs translating' do
+      let(:account_number) { '111020145685' }
+      its([:bank_code]) { is_expected.to eq('22') }
+      its([:account_number]) { is_expected.to eq('00111020145685') }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'Spain' do
+    let(:country_code) { 'ES' }
+    let(:bank_code) { '2310' }
+    let(:branch_code) { '0001' }
+    let(:account_number) { '180000012345' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with bank and branch codes in the account number' do
+      let(:bank_code) { nil }
+      let(:branch_code) { nil }
+      let(:account_number) { '23100001180000012345' }
+
+      its([:bank_code]) { is_expected.to eq('2310') }
+      its([:branch_code]) { is_expected.to eq('0001') }
+      its([:account_number]) { is_expected.to eq('180000012345') }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'Finland' do
+    let(:country_code) { 'FI' }
+    let(:bank_code) { '123456' }
+    let(:account_number) { '00000785' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with a shorter account number' do
+      let(:account_number) { '785' }
+      its([:account_number]) { is_expected.to eq('00000785') }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'France' do
+    let(:country_code) { 'FR' }
+    let(:bank_code) { '20041' }
+    let(:branch_code) { '01005' }
+    let(:account_number) { '0500013M02606' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with the RIB key spaced in the account number' do
+      let(:account_number) { '0500013M026 06' }
+      its([:account_number]) { is_expected.to eq('0500013M02606') }
+    end
+
+    context 'with the RIB key hyphenated in the account number' do
+      let(:account_number) { '0500013M026-06' }
+      its([:account_number]) { is_expected.to eq('0500013M02606') }
+    end
+
+    context 'with the RIB key missing' do
+      let(:account_number) { '0500013M026' }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a branch code' do
+      let(:branch_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'United Kingdom' do
+    let(:country_code) { 'GB' }
+    let(:bank_code) { 'BARC' }
+    let(:branch_code) { '200000' }
+    let(:account_number) { '55779911' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with the sort code is hyphenated' do
+      let(:branch_code) { '20-00-00' }
+      its([:branch_code]) { is_expected.to eq('200000') }
+    end
+
+    context 'with the sort code spaced' do
+      let(:branch_code) { '20 00 00' }
+      its([:branch_code]) { is_expected.to eq('200000') }
+    end
+
+    context 'with a short account number' do
+      let(:account_number) { '579135' }
+      its([:account_number]) { is_expected.to eq('00579135') }
+    end
+
+    context 'with the account number spaced' do
+      let(:account_number) { '5577 9911' }
+      its([:account_number]) { is_expected.to eq('55779911') }
+    end
+
+    context 'with the account number hyphenated' do
+      let(:account_number) { '5577-9911' }
+      its([:account_number]) { is_expected.to eq('55779911') }
+    end
+
+    context 'without a branch code' do
+      let(:branch_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+
+      context 'with a BIC finder set' do
+        let(:bic_finder) { double }
+        before do
+          allow(bic_finder).to receive(:call).with('GB', '200000').
+            and_return('BARCGB22XXX')
+          Ibandit.bic_finder = bic_finder
+        end
+        after { Ibandit.bic_finder = nil }
+
+        its([:bank_code]) { is_expected.to eq('BARC') }
+      end
+    end
+
+    context 'with a bank code and BIC finder set' do
+      let(:bank_code) { 'OVERRIDE' }
+      let(:bic_finder) { double }
+      before do
+        allow(bic_finder).to receive(:call).with('GB', '200000').
+          and_return('BARCGB22XXX')
+        Ibandit.bic_finder = bic_finder
+      end
+      after { Ibandit.bic_finder = nil }
+
+      its([:bank_code]) { is_expected.to eq('OVERRIDE') }
+    end
+  end
+
+  context 'Ireland' do
+    let(:country_code) { 'IE' }
+    let(:bank_code) { 'AIBK' }
+    let(:branch_code) { '931152' }
+    let(:account_number) { '12345678' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with the sort code is hyphenated' do
+      let(:branch_code) { '93-11-52' }
+      its([:branch_code]) { is_expected.to eq('931152') }
+    end
+
+    context 'with the sort code spaced' do
+      let(:branch_code) { '93 11 52' }
+      its([:branch_code]) { is_expected.to eq('931152') }
+    end
+
+    context 'with a short account number' do
+      let(:account_number) { '579135' }
+      its([:account_number]) { is_expected.to eq('00579135') }
+    end
+
+    context 'with the account number spaced' do
+      let(:account_number) { '5577 9911' }
+      its([:account_number]) { is_expected.to eq('55779911') }
+    end
+
+    context 'with the account number hyphenated' do
+      let(:account_number) { '5577-9911' }
+      its([:account_number]) { is_expected.to eq('55779911') }
+    end
+
+    context 'without a branch code' do
+      let(:branch_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+
+      context 'with a BIC finder set' do
+        let(:bic_finder) { double }
+        before do
+          allow(bic_finder).to receive(:call).with('IE', '931152').
+            and_return('AIBKIE22XXX')
+          Ibandit.bic_finder = bic_finder
+        end
+        after { Ibandit.bic_finder = nil }
+
+        its([:bank_code]) { is_expected.to eq('AIBK') }
+      end
+    end
+
+    context 'with a bank code and BIC finder set' do
+      let(:bank_code) { 'OVERRIDE' }
+      let(:bic_finder) { double }
+      before do
+        allow(bic_finder).to receive(:call).with('IE', '931152').
+          and_return('AIBKIE22XXX')
+        Ibandit.bic_finder = bic_finder
+      end
+      after { Ibandit.bic_finder = nil }
+
+      its([:bank_code]) { is_expected.to eq('OVERRIDE') }
+    end
+  end
+
+  context 'Italy' do
+    let(:country_code) { 'IT' }
+    let(:bank_code) { '05428' }
+    let(:branch_code) { '11101' }
+    let(:account_number) { '000000123456' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with an explicit check digit' do
+      before { local_details.merge!(check_digit: 'Y') }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'with the account number not zero-padded' do
+      let(:account_number) { '123456' }
+      its([:account_number]) { is_expected.to eq('000000123456') }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a branch code' do
+      let(:branch_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'Lithuania' do
+    let(:country_code) { 'LT' }
+    let(:bank_code) { '10000' }
+    let(:account_number) { '11101001000' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'Luxembourg' do
+    let(:country_code) { 'LU' }
+    let(:bank_code) { '001' }
+    let(:account_number) { '9400644750000' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'Latvia' do
+    let(:country_code) { 'LV' }
+    let(:bank_code) { 'BANK' }
+    let(:account_number) { '1234567890123' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'Monaco' do
+    let(:country_code) { 'MC' }
+    let(:bank_code) { '20041' }
+    let(:branch_code) { '01005' }
+    let(:account_number) { '0500013M02606' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with the RIB key spaced in the account number' do
+      let(:account_number) { '0500013M026 06' }
+      its([:account_number]) { is_expected.to eq('0500013M02606') }
+    end
+
+    context 'with the RIB key hyphenated in the account number' do
+      let(:account_number) { '0500013M026-06' }
+      its([:account_number]) { is_expected.to eq('0500013M02606') }
+    end
+
+    context 'with the RIB key missing' do
+      let(:account_number) { '0500013M026' }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a branch code' do
+      let(:branch_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'Netherlands' do
+    let(:country_code) { 'NL' }
+    let(:bank_code) { 'ABNA' }
+    let(:account_number) { '0417164300' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a branch code' do
+      let(:branch_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'with an account number that needs zero-padding' do
+      let(:account_number) { '417164300' }
+      its([:account_number]) { is_expected.to eq('0417164300') }
+    end
+  end
+
+  context 'Portugal' do
+    let(:country_code) { 'PT' }
+    let(:bank_code) { '0002' }
+    let(:branch_code) { '0023' }
+    let(:account_number) { '0023843000578' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a branch code' do
+      let(:branch_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'Slovenia' do
+    let(:country_code) { 'SI' }
+    let(:bank_code) { '19100' }
+    let(:account_number) { '0000123438' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with an account number which needs zero-padding' do
+      let(:account_number) { '123438' }
+      its([:account_number]) { is_expected.to eq('0000123438') }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'Slovak Republic' do
+    let(:country_code) { 'SK' }
+    let(:bank_code) { '1200' }
+    let(:account_number) { '0000198742637541' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with an account number prefix' do
+      let(:prefix) { '000019' }
+      let(:account_number) { '8742637541' }
+      before { local_details.merge!(account_number_prefix: prefix) }
+
+      its([:account_number]) { is_expected.to eq('0000198742637541') }
+
+      context 'which needs zero-padding' do
+        let(:prefix) { '19' }
+        its([:account_number]) { is_expected.to eq('0000198742637541') }
+      end
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+
+  context 'San Marino' do
+    let(:country_code) { 'SM' }
+    let(:bank_code) { '05428' }
+    let(:branch_code) { '11101' }
+    let(:account_number) { '000000123456' }
+
+    it { is_expected.to eq(local_details) }
+
+    context 'with an explicit check digit' do
+      before { local_details.merge!(check_digit: 'Y') }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'with the account number not zero-padded' do
+      let(:account_number) { '123456' }
+      its([:account_number]) { is_expected.to eq('000000123456') }
+    end
+
+    context 'without a bank code' do
+      let(:bank_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without a branch code' do
+      let(:branch_code) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+
+    context 'without an account number' do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details) }
+    end
+  end
+end

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -36,6 +36,11 @@ describe Ibandit::LocalDetailsCleaner do
       its([:account_number]) { is_expected.to eq('00234573201') }
     end
 
+    context 'with an account number under 4 digits' do
+      let(:account_number) { '123' }
+      its([:account_number]) { is_expected.to eq('123') }
+    end
+
     context 'with a long account number' do
       let(:account_number) { '234573201999' }
       it { is_expected.to eq(local_details) }
@@ -92,6 +97,11 @@ describe Ibandit::LocalDetailsCleaner do
       its([:account_number]) { is_expected.to eq('0000001200527600') }
     end
 
+    context 'with a too-short account number' do
+      let(:account_number) { '123456' }
+      its([:account_number]) { is_expected.to eq(account_number) }
+    end
+
     context 'with a long account number' do
       let(:account_number) { '00000001200527600' }
       it { is_expected.to eq(local_details) }
@@ -132,6 +142,11 @@ describe Ibandit::LocalDetailsCleaner do
       it { is_expected.to eq(local_details) }
     end
 
+    context 'with an excessively short account number' do
+      let(:account_number) { '666' }
+      its([:account_number]) { is_expected.to eq(account_number) }
+    end
+
     context 'with a pseudo account number' do
       let(:bank_code) { '37080040' }
       let(:account_number) { '111' }
@@ -170,7 +185,7 @@ describe Ibandit::LocalDetailsCleaner do
     context 'with bank and branch codes in the account number' do
       let(:bank_code) { nil }
       let(:branch_code) { nil }
-      let(:account_number) { '23100001180000012345' }
+      let(:account_number) { '2310-0001-18-0000012345' }
 
       its([:bank_code]) { is_expected.to eq('2310') }
       its([:branch_code]) { is_expected.to eq('0001') }
@@ -268,6 +283,11 @@ describe Ibandit::LocalDetailsCleaner do
       its([:account_number]) { is_expected.to eq('00579135') }
     end
 
+    context 'with a too-short account number' do
+      let(:account_number) { '5678' }
+      its([:account_number]) { is_expected.to eq(account_number) }
+    end
+
     context 'with the account number spaced' do
       let(:account_number) { '5577 9911' }
       its([:account_number]) { is_expected.to eq('55779911') }
@@ -335,6 +355,11 @@ describe Ibandit::LocalDetailsCleaner do
     context 'with a short account number' do
       let(:account_number) { '579135' }
       its([:account_number]) { is_expected.to eq('00579135') }
+    end
+
+    context 'with a too-short account number' do
+      let(:account_number) { '5678' }
+      its([:account_number]) { is_expected.to eq(account_number) }
     end
 
     context 'with the account number spaced' do


### PR DESCRIPTION
Another one which builds on #13. AT/DE account numbers are >= 4 digits, UK/IE are >= 6 digits, CY are >= 7. We shouldn't just blindly zero-pad values shorter than these.