### PR TITLE
Allow for injection of a modulus checker

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ LineLength:
   Max: 80
 
 ClassLength:
-  Max: 200
+  Max: 300
 
 # Avoid single-line methods.
 SingleLineMethods:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ The following error keys may be set:
 - `length`
 - `format`
 
+Ibandit will also apply local modulus checks if you set a modulus checker:
+
+```ruby
+module ModulusChecker
+  def self.valid_bank_code?(iban_string)
+    some_codes
+  end
+  
+  def self.valid_account_number?(iban_string)
+    some_codes
+  end
+end
+
+Ibandit.modulus_checker = ModulusChecker
+```
+
+Both the `valid_bank_code?` and `valid_account_number?` methods will receive the plain-text IBAN.
+`valid_bank_code?` should return true unless it is known that the bank/branch code in this IBAN are
+invalid in the country specified. `valid_account_number?` should return true unless it is known that
+the account number in this IBAN cannot be valid due to local modulus checking rules.
+
 ### Deconstructing an IBAN into national banking details
 
 SWIFT define the following components for IBANs, and publish details of how each

--- a/lib/ibandit.rb
+++ b/lib/ibandit.rb
@@ -9,7 +9,7 @@ require 'ibandit/check_digit'
 
 module Ibandit
   class << self
-    attr_accessor :bic_finder
+    attr_accessor :bic_finder, :modulus_checker
 
     def find_bic(country_code, national_id)
       raise NotImplementedError, 'BIC finder is not defined' unless @bic_finder


### PR DESCRIPTION
It's optional (the validation always returns `true` if you haven't set one), but you can now do:
```ruby
module ModulusChecker
  def self.valid_bank_code?(iban_string)
    some_codes
  end

  def self.valid_account_number?(iban_string)
    some_codes
  end
end

Ibandit.modulus_checker = ModulusChecker
```

and Ibandit will run those and attach any `bank_code` errors to the `bank_code` if that's required for the country, or `branch_code` otherwise (eg. in the UK with a BIC finder set). If `valid_account_number?` returns false the error will get attached to `account_number`.

@greysteil could you review?