### PR TITLE
Silence UnsupportedAccountDetails errors when cleaning bank details

### DIFF
--- a/lib/ibandit/errors.rb
+++ b/lib/ibandit/errors.rb
@@ -1,6 +1,4 @@
 module Ibandit
-  class BicNotFoundError < StandardError; end
   class InvalidCharacterError < StandardError; end
-  class UnsupportedCountryError < StandardError; end
   class UnsupportedAccountDetails < StandardError; end
 end

--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -68,7 +68,8 @@ module Ibandit
         valid_bank_code_format?,
         valid_branch_code_format?,
         valid_account_number_format?,
-        valid_local_modulus_check?
+        valid_local_modulus_check?,
+        supports_iban_determination?
       ].all?
     end
 
@@ -222,6 +223,23 @@ module Ibandit
       return true unless Ibandit.modulus_checker
 
       valid_modulus_check_bank_code? && valid_modulus_check_account_number?
+    end
+
+    def supports_iban_determination?
+      return unless valid_format?
+      return true unless country_code == 'DE'
+
+      begin
+        GermanDetailsConverter.convert(
+          country_code: country_code,
+          bank_code: bank_code,
+          account_number: account_number
+        )
+        true
+      rescue UnsupportedAccountDetails
+        @errors[:account_number] = Ibandit.translate(:is_invalid)
+        false
+      end
     end
 
     ###################

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -96,7 +96,12 @@ module Ibandit
       # There are many exceptions to the way German bank details translate
       # into an IBAN, detailed into a 200 page document compiled by the
       # Bundesbank, and handled by the GermanDetailsConverter class.
-      converted_details = GermanDetailsConverter.convert(local_details)
+      converted_details =
+        begin
+          GermanDetailsConverter.convert(local_details)
+        rescue UnsupportedAccountDetails
+          local_details.dup
+        end
 
       return {} unless converted_details[:account_number].length >= 4
 

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -1220,6 +1220,29 @@ describe Ibandit::IBAN do
         end
       end
     end
+
+    describe 'supports_iban_determination?' do
+      subject(:valid_local_modulus_check?) { iban.supports_iban_determination? }
+
+      context 'with unsupported account details' do
+        let(:arg) do
+          {
+            country_code: 'DE',
+            bank_code: '20000000',
+            account_number: '7955791111'
+          }
+        end
+
+        it { is_expected.to eq(false) }
+
+        context 'locale de', locale: :de do
+          it 'sets errors on the IBAN' do
+            iban.supports_iban_determination?
+            expect(iban.errors).to include(account_number: 'ist nicht gültig')
+          end
+        end
+      end
+    end
   end
 
   describe '#valid?' do

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -156,6 +156,12 @@ describe Ibandit::LocalDetailsCleaner do
       its([:bank_code]) { is_expected.to eq(bank_code) }
       its([:account_number]) { is_expected.to eq('0215022000') }
     end
+
+    context 'with unsupported account details' do
+      let(:account_number) { '7955791111' }
+      let(:bank_code) { '20000000' }
+      it { is_expected.to eq(local_details) }
+    end
   end
 
   context 'Estonia' do


### PR DESCRIPTION
Catch and silence any `UnsupportedAccountDetails` errors when cleaning a German bank account. It feels right for `GermanDetailsConverter` to raise these errors, but when we're just cleaning some bank details we don't want to raise for them. Instead the German IBAN rules should probably be considered at modulus check time.