### PR TITLE
Clean up swedish details converter

### DIFF
--- a/data/raw/swedish_bank_lookup.yml
+++ b/data/raw/swedish_bank_lookup.yml
@@ -3,261 +3,375 @@
 # - https://sv.wikipedia.org/wiki/Lista_%C3%B6ver_clearingnummer_till_svenska_banker
 # - http://www.bgc.se/globalassets/dokument/tekniska-manualer/bankernaskontonummeruppbyggnad_tekniskmanual_sv.pdf
 # - SWIFT IBAN data
+#
+# Fields:
+# - Range:                  The range of clearing codes for this bank. Used to
+#                           find the bank information for a given account number.
+#
+# - Bank:                   The name of the bank.
+#
+# - Clearing code length:   Length of the clearing codes issued by this bank. This
+#                           is 4 in all cases except Swedbank's 8000-range.
+#
+# - Serial number length:   Length of the account number that follows the clearing
+#                           code.
+#
+# - Include clearing code:  Whether the clearing code is included in the IBAN account
+#                           number.
+#
+# - Zerofill serial number: Whether the serial number should be zerofilled if it is
+#                           shorter than the required serial_number_length.
+#
 - :range: [1100, 1199]
   :bank: Nordea
   :bank_code: 300
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [1200, 1399]
   :bank: Danske Bank
   :bank_code: 120
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [1400, 2099]
   :bank: Nordea
   :bank_code: 300
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [2300, 2399]
   :bank: Ålandsbanken Sverige AB
   :bank_code: 230
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [2400, 2499]
   :bank: Danske Bank
   :bank_code: 120
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
   # NOTE: We're ignoring Sambox bank (clearing number 2950) because the only
   # reference I've seen is wikipedia. Sambox does have its own bank code (295)
   # though, so we may want to revisit.
 - :range: [3000, 3299]
   :bank: Nordea
   :bank_code: 300
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [3300, 3300]
   :bank: Nordea Personkonto
   # NOTE: We're routing Nordea Personkonto to the main Nordea bank code, but
-  # it may belong at one of the other Nordea codes we're bot currently using.
+  # it may belong at one of the other Nordea codes we're not currently using.
   :bank_code: 300
-  :type: 2
   :clearing_code_length: 4
+  :serial_number_length: 10
+  :zerofill_serial_number: false
+  :include_clearing_code: false
 - :range: [3301, 3399]
   :bank: Nordea
   :bank_code: 300
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [3400, 3409]
   :bank: Länsförsäkringar Bank
   :bank_code: 902
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [3410, 3781]
   :bank: Nordea
   :bank_code: 300
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [3782, 3782]
   :bank: Nordea Personkonto
   # NOTE: We're routing Nordea Personkonto to the main Nordea bank code, but
-  # it may belong at one of the other Nordea codes we're bot currently using.
+  # it may belong at one of the other Nordea codes we're not currently using.
   :bank_code: 300
-  :type: 2
   :clearing_code_length: 4
+  :serial_number_length: 10
+  :zerofill_serial_number: false
+  :include_clearing_code: fase
 - :range: [3783, 3999]
   :bank: Nordea
   :bank_code: 300
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [4000, 4999]
   :bank: Nordea
   :bank_code: 300
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [5000, 5999]
   :bank: SEB
   :bank_code: 500
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [6000, 6999]
   :bank: Handelsbanken
   :bank_code: 600
-  :type: 2
   :clearing_code_length: 4
+  :serial_number_length: 9
+  :zerofill_serial_number: true
+  :include_clearing_code: false
 - :range: [7000, 7999]
   :bank: Swedbank
   :bank_code: 800
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [8000, 8999]
   # NOTE: This range also includes independent savings banks, some of which
   # appear to have their own bank code. For now we always use the Swedbank bank
   # code - we should revisit if we see failures as a result.
   :bank: Swedbank
   :bank_code: 800
-  :type: 2
   :clearing_code_length: 5
-  :zerofill: true
+  :serial_number_length: 10
+  :zerofill_serial_number: true
+  :include_clearing_code: true
 - :range: [9020, 9029]
   :bank: Länsförsäkringar Bank
   :bank_code: 902
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9040, 9049]
   :bank: Citibank
   :bank_code: 904
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9060, 9069]
   :bank: Länsförsäkringar Bank
   :bank_code: 902
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9090, 9099]
   :bank: ABN Amro
   :bank_code: 909
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9100, 9109]
   :bank: Nordnet Bank
   :bank_code: 910
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9120, 9124]
   :bank: SEB
   :bank_code: 500
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9130, 9149]
   :bank: SEB
   :bank_code: 500
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9150, 9169]
   :bank: Skandiabanken
   :bank_code: 915
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9170, 9179]
   :bank: IKANO Bank
   :bank_code: 917
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9180, 9189]
   :bank: Danske Bank
   :bank_code: 120
-  :type: 2
   :clearing_code_length: 4
+  :serial_number_length: 10
+  :zerofill_serial_number: false
+  :include_clearing_code: false
 - :range: [9190, 9199]
   :bank: Den Norske Bank
   :bank_code: 919
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9230, 9239]
   :bank: Marginalen Bank
   :bank_code: 923
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9250, 9259]
   :bank: SBAB
   :bank_code: 925
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9260, 9269]
   :bank: Den Norske Bank
   :bank_code: 919
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9270, 9279]
   :bank: ICA Banken
   :bank_code: 927
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9280, 9289]
   :bank: Resurs Banken AB
   :bank_code: 928
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9300, 9329]
   :bank: Sparbanken Öresund
   :bank_code: 930
-  :type: 2
   :clearing_code_length: 4
+  :serial_number_length: 10
+  :zerofill_serial_number: false
+  :include_clearing_code: false
 - :range: [9330, 9349]
   :bank: Sparbanken Öresund
   :bank_code: 933
-  :type: 2
   :clearing_code_length: 4
+  :serial_number_length: 10
+  :zerofill_serial_number: false
+  :include_clearing_code: false
 - :range: [9390, 9399]
   :bank: Landshypotek AB
   :bank_code: 939
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9400, 9449]
   :bank: Forex Bank AB
   :bank_code: 940
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9460, 9469]
   :bank: GE Money Bank
   :bank_code: 945
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9470, 9479]
   :bank: BNP Paribas
   :bank_code: 947
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9500, 9549]
   :bank: Nordea - PlusGirot
   :bank_code: 950
-  :type: 2
   :clearing_code_length: 4
-  :zerofill: true
+  :serial_number_length: 10
+  :zerofill_serial_number: true
+  :include_clearing_code: true
 - :range: [9550, 9569]
   :bank: Avanza Bank
   :bank_code: 955
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9570, 9579]
   :bank: Sparbanken Syd
   :bank_code: 957
-  :type: 2
   :clearing_code_length: 4
+  :serial_number_length: 10
+  :zerofill_serial_number: false
+  :include_clearing_code: false
 - :range: [9590, 9599]
   :bank: Erik Penser AB
   :bank_code: 959
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9630, 9639]
   :bank: "Lån & Spar Bank"
   :bank_code: 963
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9640, 9649]
   :bank: Nordax Finans
   :bank_code: 964
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9660, 9669]
   :bank: Amfa Bank
   :bank_code: 966
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9880, 9889]
   :bank: Riksgälden
   :bank_code: 988
-  :type: 1
   :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
 - :range: [9890, 9899]
   :bank: Riksgälden
   :bank_code: 989
-  :type: 2
   :clearing_code_length: 4
+  :serial_number_length: 10
+  :zerofill_serial_number: false
+  :include_clearing_code: false
 - :range: [9960, 9969]
   :bank: Nordea - PlusGirot
   :bank_code: 950
-  :type: 2
   :clearing_code_length: 4
-  :zerofill: true
+  :serial_number_length: 10
+  :zerofill_serial_number: true
+  :include_clearing_code: true

--- a/spec/ibandit/swedish_details_converter_spec.rb
+++ b/spec/ibandit/swedish_details_converter_spec.rb
@@ -41,8 +41,7 @@ describe Ibandit::SwedishDetailsConverter do
       let(:account_number) { '1281-1' }
 
       its([:bank_code]) { is_expected.to eq('120') }
-      # TODO: Decide whether we should be zero-padding here or not
-      its([:account_number]) { is_expected.to eq('00000012810000001') }
+      its([:account_number]) { is_expected.to eq('00000000000012811') }
     end
   end
 
@@ -106,6 +105,13 @@ describe Ibandit::SwedishDetailsConverter do
 
       its([:bank_code]) { is_expected.to eq('600') }
       its([:account_number]) { is_expected.to eq('00000000219161038') }
+    end
+
+    context 'that only has an 8 digit serial number' do
+      let(:account_number) { '6240-21916103' }
+
+      its([:bank_code]) { is_expected.to eq('600') }
+      its([:account_number]) { is_expected.to eq('00000000021916103') }
     end
   end
 


### PR DESCRIPTION
Replace `type` attribute with explicit details of how the conversion should work.