### PR TITLE
Return Swedish branch codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ county combines them:
 `check_digits`
 :    Two digits calculated using part of the ISO/IEC 7064:2003 standard
 
-`bank_code`
+`swift_bank_code`
 :    The SWIFT identifier for the bank to which the IBAN refers
 
-`branch_code`
+`swift_branch_code`
 :    The SWIFT identifer for the branch to which the IBAN refers (not used in all countries)
 
-`account_number`
+`swift_account_number`
 :    The account number for the account
 
 `iban_national_id`
@@ -116,9 +116,9 @@ iban = Ibandit::IBAN.new("GB82 WEST 1234 5698 7654 32")
 
 iban.country_code              # => "GB"
 iban.check_digits              # => "82"
-iban.bank_code                 # => "WEST"
-iban.branch_code               # => "123456"
-iban.account_number            # => "98765432"
+iban.swift_bank_code           # => "WEST"
+iban.swift_branch_code         # => "123456"
+iban.swift_account_number      # => "98765432"
 iban.iban_national_id          # => "WEST123456"
 ```
 
@@ -129,6 +129,23 @@ These are available through a `local_check_digits` method:
 iban = Ibandit::IBAN.new("ES12 1234 5678 9112 3456 7890")
 
 iban.local_check_digits        # => "91"
+```
+
+In some countries, the SWIFT-defined details differ from the local details that
+customers are familiar with.  For this reason, there are also `bank_code`,
+`branch_code` and `account_number` methods on an `IBAN` object.  At present,
+these only differ from the `swift_` equivalents for Swedish bank accounts.
+
+```ruby
+iban = Ibandit::IBAN.new(
+  country_code: 'SE',
+  account_number: '7507-1211203'
+)
+iban.swift_account_number      # => "75071211203"
+iban.account_number            # => "1211203"
+
+iban.swift_branch_code         # => nil
+iban.branch_code               # => "7507"
 ```
 
 ### Initializing Ibandit

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -7,6 +7,8 @@ module Ibandit
     def self.clean(local_details)
       country_code = local_details[:country_code]
 
+      local_details = swift_details_for(local_details).merge(local_details)
+
       return local_details unless can_clean?(country_code, local_details)
 
       local_details.merge(
@@ -477,5 +479,14 @@ module Ibandit
       hufo + reikningsnumer + kennitala
     end
     private_class_method :pad_is_account_number
+
+    def self.swift_details_for(local_details)
+      {
+        swift_bank_code:      local_details[:bank_code],
+        swift_branch_code:    local_details[:branch_code],
+        swift_account_number: local_details[:account_number]
+      }
+    end
+    private_class_method :swift_details_for
   end
 end

--- a/lib/ibandit/swedish_details_converter.rb
+++ b/lib/ibandit/swedish_details_converter.rb
@@ -7,8 +7,8 @@ module Ibandit
       bank_info = bank_info_for(cleaned_account_number.slice(0, 4))
 
       if bank_info.nil?
-        return { bank_code: nil,
-                 account_number: cleaned_account_number.rjust(17, '0') }
+        return { swift_bank_code: nil,
+                 swift_account_number: cleaned_account_number.rjust(17, '0') }
       end
 
       clearing_code_length = bank_info.fetch(:clearing_code_length)
@@ -21,16 +21,14 @@ module Ibandit
         serial_number = serial_number.rjust(serial_number_length, '0')
       end
 
-      iban_account_number =
-        if bank_info.fetch(:include_clearing_code)
-          (clearing_code + serial_number).rjust(17, '0')
-        else
-          serial_number.rjust(17, '0')
-        end
-
+      swift_account_number = build_swift_account_number(bank_info,
+                                                        clearing_code,
+                                                        serial_number)
       {
-        bank_code: bank_info.fetch(:bank_code).to_s,
-        account_number: iban_account_number
+        account_number: serial_number,
+        branch_code: clearing_code,
+        swift_bank_code: bank_info.fetch(:bank_code).to_s,
+        swift_account_number: swift_account_number
       }
     end
 
@@ -97,5 +95,14 @@ module Ibandit
         end
     end
     private_class_method :bank_info_table
+
+    def self.build_swift_account_number(bank_info, clearing_code, serial_number)
+      if bank_info.fetch(:include_clearing_code)
+        (clearing_code + serial_number).rjust(17, '0')
+      else
+        serial_number.rjust(17, '0')
+      end
+    end
+    private_class_method :build_swift_account_number
   end
 end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -49,6 +49,9 @@ describe Ibandit::IBAN do
     its(:bank_code) { is_expected.to eq('WEST') }
     its(:branch_code) { is_expected.to eq('123456') }
     its(:account_number) { is_expected.to eq('98765432') }
+    its(:swift_bank_code) { is_expected.to eq('WEST') }
+    its(:swift_branch_code) { is_expected.to eq('123456') }
+    its(:swift_account_number) { is_expected.to eq('98765432') }
     its(:iban_national_id) { is_expected.to eq('WEST123456') }
     its(:local_check_digits) { is_expected.to be_nil }
 
@@ -79,6 +82,9 @@ describe Ibandit::IBAN do
       its(:bank_code) { is_expected.to eq(arg[:bank_code]) }
       its(:branch_code) { is_expected.to eq(arg[:branch_code]) }
       its(:account_number) { is_expected.to eq(arg[:account_number]) }
+      its(:swift_bank_code) { is_expected.to eq(arg[:bank_code]) }
+      its(:swift_branch_code) { is_expected.to eq(arg[:branch_code]) }
+      its(:swift_account_number) { is_expected.to eq(arg[:account_number]) }
     end
   end
 
@@ -358,7 +364,7 @@ describe Ibandit::IBAN do
     end
 
     context 'with invalid details' do
-      before { allow(iban).to receive(:bank_code).and_return('WES') }
+      before { allow(iban).to receive(:swift_bank_code).and_return('WES') }
       it { is_expected.to eq(false) }
 
       context 'locale en', locale: :en do
@@ -444,7 +450,7 @@ describe Ibandit::IBAN do
     end
 
     context 'with invalid details' do
-      before { allow(iban).to receive(:branch_code).and_return('12345') }
+      before { allow(iban).to receive(:swift_branch_code).and_return('12345') }
       it { is_expected.to eq(false) }
 
       context 'locale en', locale: :en do
@@ -512,7 +518,7 @@ describe Ibandit::IBAN do
     end
 
     context 'without a branch code' do
-      before { allow(iban).to receive(:branch_code).and_return(nil) }
+      before { allow(iban).to receive(:swift_branch_code).and_return(nil) }
       it { is_expected.to eq(false) }
 
       context 'locale en', locale: :en do
@@ -584,7 +590,9 @@ describe Ibandit::IBAN do
     end
 
     context 'with an invalid account_number' do
-      before { allow(iban).to receive(:account_number).and_return('1234567') }
+      before do
+        allow(iban).to receive(:swift_account_number).and_return('1234567')
+      end
       it { is_expected.to eq(false) }
 
       context 'locale en', locale: :en do

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -955,19 +955,22 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '501' }
     let(:account_number) { '5013-1007270' }
 
-    its([:bank_code]) { is_expected.to eq('501') }
-    its([:account_number]) { is_expected.to eq('00000050131007270') }
+    its([:account_number]) { is_expected.to eq('1007270') }
+    its([:branch_code]) { is_expected.to eq('5013') }
+    its([:swift_bank_code]) { is_expected.to eq('501') }
+    its([:swift_account_number]) { is_expected.to eq('00000050131007270') }
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details_with_swift) }
+      it { is_expected.to eq(local_details) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
 
-      its([:bank_code]) { is_expected.to eq('500') }
-      its([:account_number]) { is_expected.to eq('00000050131007270') }
+      its([:swift_bank_code]) { is_expected.to eq('500') }
+      its([:account_number]) { is_expected.to eq('1007270') }
+      its([:swift_account_number]) { is_expected.to eq('00000050131007270') }
     end
   end
 

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -10,18 +10,27 @@ describe Ibandit::LocalDetailsCleaner do
       account_number: account_number
     }
   end
+
+  let(:local_details_with_swift) do
+    local_details.merge(
+      swift_bank_code:      bank_code,
+      swift_branch_code:    branch_code,
+      swift_account_number: account_number
+    )
+  end
+
   let(:country_code) { nil }
   let(:bank_code) { nil }
   let(:branch_code) { nil }
   let(:account_number) { nil }
 
   context 'without country code' do
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
   end
 
   context 'with an unsupported country code' do
     let(:country_code) { 'FU' }
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
   end
 
   context 'Austria' do
@@ -29,7 +38,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '19043' }
     let(:account_number) { '00234573201' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with an account number which needs zero-padding' do
       let(:account_number) { '234573201' }
@@ -43,27 +52,27 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'with a long account number' do
       let(:account_number) { '234573201999' }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'with a short bank code' do
       let(:bank_code) { '1904' }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'with a long bank code' do
       let(:bank_code) { '190430' }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -83,7 +92,7 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -93,21 +102,21 @@ describe Ibandit::LocalDetailsCleaner do
     let(:branch_code) { '9661' }
     let(:account_number) { '1020345678' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a branch code' do
       let(:branch_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -117,7 +126,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '002' }
     let(:branch_code) { '00128' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with a short account number' do
       let(:account_number) { '1200527600' }
@@ -131,12 +140,12 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'with a long account number' do
       let(:account_number) { '00000001200527600' }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'with the branch code in the bank code field' do
@@ -148,7 +157,7 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -157,7 +166,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '0800' }
     let(:account_number) { '0000192000145399' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with an account number prefix' do
       let(:prefix) { '000019' }
@@ -174,12 +183,12 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -188,16 +197,16 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '37040044' }
     let(:account_number) { '0532013000' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'with an excessively short account number' do
@@ -215,7 +224,7 @@ describe Ibandit::LocalDetailsCleaner do
     context 'with unsupported account details' do
       let(:account_number) { '7955791111' }
       let(:bank_code) { '20000000' }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -238,7 +247,7 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -257,7 +266,7 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -267,7 +276,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:branch_code) { '0001' }
     let(:account_number) { '180000012345' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with bank and branch codes in the account number' do
       let(:bank_code) { nil }
@@ -281,7 +290,7 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -290,7 +299,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '123456' }
     let(:account_number) { '00000785' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with a shorter account number' do
       let(:account_number) { '785' }
@@ -307,12 +316,12 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -322,7 +331,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:branch_code) { '01005' }
     let(:account_number) { '0500013M02606' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with the RIB key spaced in the account number' do
       let(:account_number) { '0500013M026 06' }
@@ -336,22 +345,22 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'with the RIB key missing' do
       let(:account_number) { '0500013M026' }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a branch code' do
       let(:branch_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -361,7 +370,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:branch_code) { '200000' }
     let(:account_number) { '55779911' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with the sort code is hyphenated' do
       let(:branch_code) { '20-00-00' }
@@ -395,12 +404,12 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without a branch code' do
       let(:branch_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
 
       context 'with a BIC finder set' do
         let(:bic_finder) { double }
@@ -435,21 +444,21 @@ describe Ibandit::LocalDetailsCleaner do
     let(:branch_code) { '0125' }
     let(:account_number) { '0000000012300695' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a branch code' do
       let(:branch_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -458,7 +467,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '1001005' }
     let(:account_number) { '1863000160' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with bank code in the account number' do
       let(:bank_code) { nil }
@@ -470,13 +479,13 @@ describe Ibandit::LocalDetailsCleaner do
 
       context 'with a badly formatted account number' do
         let(:account_number) { '1863000160' }
-        it { is_expected.to eq(local_details) }
+        it { is_expected.to eq(local_details_with_swift) }
       end
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -486,7 +495,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:branch_code) { '7301' }
     let(:account_number) { '61111101800000000' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with bank and branch codes in the account number' do
       let(:bank_code) { nil }
@@ -510,19 +519,19 @@ describe Ibandit::LocalDetailsCleaner do
 
       context 'with an invalid length account number' do
         let(:account_number) { '11773016-1111101' }
-        it { is_expected.to eq(local_details) }
+        it { is_expected.to eq(local_details_with_swift) }
       end
 
       context 'with a bank code, too' do
         let(:account_number) { '11773016-11111018' }
         let(:bank_code) { '117' }
-        it { is_expected.to eq(local_details) }
+        it { is_expected.to eq(local_details_with_swift) }
       end
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -532,7 +541,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:branch_code) { '931152' }
     let(:account_number) { '12345678' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with the sort code is hyphenated' do
       let(:branch_code) { '93-11-52' }
@@ -566,12 +575,12 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without a branch code' do
       let(:branch_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
 
       context 'with a BIC finder set' do
         let(:bic_finder) { double }
@@ -642,7 +651,7 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -652,11 +661,11 @@ describe Ibandit::LocalDetailsCleaner do
     let(:branch_code) { '11101' }
     let(:account_number) { '000000123456' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with an explicit check digit' do
       before { local_details.merge!(check_digit: 'Y') }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'with the account number not zero-padded' do
@@ -666,17 +675,17 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a branch code' do
       let(:branch_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -685,16 +694,16 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '10000' }
     let(:account_number) { '11101001000' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -703,16 +712,16 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '001' }
     let(:account_number) { '9400644750000' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -721,16 +730,16 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { 'BANK' }
     let(:account_number) { '1234567890123' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -740,7 +749,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:branch_code) { '01005' }
     let(:account_number) { '0500013M02606' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with the RIB key spaced in the account number' do
       let(:account_number) { '0500013M026 06' }
@@ -754,22 +763,22 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'with the RIB key missing' do
       let(:account_number) { '0500013M026' }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a branch code' do
       let(:branch_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -779,7 +788,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:branch_code) { '44093' }
     let(:account_number) { '000000009027293051' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with the account number spaced' do
       let(:account_number) { '9027 2930 51' }
@@ -793,12 +802,12 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without a branch code' do
       let(:branch_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
 
       context 'with a BIC finder set' do
         let(:bic_finder) { double }
@@ -832,21 +841,21 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { 'ABNA' }
     let(:account_number) { '0417164300' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a branch code' do
       let(:branch_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'with an account number that needs zero-padding' do
@@ -860,7 +869,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '8601' }
     let(:account_number) { '1117947' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with bank and branch codes in the account number' do
       let(:bank_code) { nil }
@@ -873,7 +882,7 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -882,7 +891,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '10201026' }
     let(:account_number) { '0000042270201111' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with a full length account number' do
       let(:bank_code) { nil }
@@ -895,7 +904,7 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -905,21 +914,21 @@ describe Ibandit::LocalDetailsCleaner do
     let(:branch_code) { '0023' }
     let(:account_number) { '0023843000578' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a branch code' do
       let(:branch_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -928,16 +937,16 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { 'AAAA' }
     let(:account_number) { '1B31007593840000' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -951,7 +960,7 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a bank code' do
@@ -967,7 +976,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '19100' }
     let(:account_number) { '0000123438' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with an account number which needs zero-padding' do
       let(:account_number) { '123438' }
@@ -976,12 +985,12 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -990,7 +999,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { '1200' }
     let(:account_number) { '0000198742637541' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with an account number prefix' do
       let(:prefix) { '000019' }
@@ -1007,12 +1016,12 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 
@@ -1022,11 +1031,11 @@ describe Ibandit::LocalDetailsCleaner do
     let(:branch_code) { '11101' }
     let(:account_number) { '000000123456' }
 
-    it { is_expected.to eq(local_details) }
+    it { is_expected.to eq(local_details_with_swift) }
 
     context 'with an explicit check digit' do
       before { local_details.merge!(check_digit: 'Y') }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'with the account number not zero-padded' do
@@ -1036,17 +1045,17 @@ describe Ibandit::LocalDetailsCleaner do
 
     context 'without a bank code' do
       let(:bank_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without a branch code' do
       let(:branch_code) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context 'without an account number' do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
   end
 end

--- a/spec/ibandit/swedish_details_converter_spec.rb
+++ b/spec/ibandit/swedish_details_converter_spec.rb
@@ -7,127 +7,163 @@ describe Ibandit::SwedishDetailsConverter do
     context 'with a type-1 account number' do
       let(:account_number) { '12810105723' }
 
-      its([:bank_code]) { is_expected.to eq('120') }
-      its([:account_number]) { is_expected.to eq('00000012810105723') }
+      its([:account_number]) { is_expected.to eq('0105723') }
+      its([:branch_code]) { is_expected.to eq('1281') }
+      its([:swift_bank_code]) { is_expected.to eq('120') }
+      its([:swift_account_number]) { is_expected.to eq('00000012810105723') }
 
       context 'that includes hyphens' do
         let(:account_number) { '1281-0105723' }
 
-        its([:bank_code]) { is_expected.to eq('120') }
-        its([:account_number]) { is_expected.to eq('00000012810105723') }
+        its([:account_number]) { is_expected.to eq('0105723') }
+        its([:branch_code]) { is_expected.to eq('1281') }
+        its([:swift_bank_code]) { is_expected.to eq('120') }
+        its([:swift_account_number]) { is_expected.to eq('00000012810105723') }
       end
 
       context 'that includes spaces' do
         let(:account_number) { '1281 0105723' }
 
-        its([:bank_code]) { is_expected.to eq('120') }
-        its([:account_number]) { is_expected.to eq('00000012810105723') }
+        its([:account_number]) { is_expected.to eq('0105723') }
+        its([:branch_code]) { is_expected.to eq('1281') }
+        its([:swift_bank_code]) { is_expected.to eq('120') }
+        its([:swift_account_number]) { is_expected.to eq('00000012810105723') }
       end
 
       context 'that includes full stops' do
         let(:account_number) { '1281.010.572.3' }
 
-        its([:bank_code]) { is_expected.to eq('120') }
-        its([:account_number]) { is_expected.to eq('00000012810105723') }
+        its([:account_number]) { is_expected.to eq('0105723') }
+        its([:branch_code]) { is_expected.to eq('1281') }
+        its([:swift_bank_code]) { is_expected.to eq('120') }
+        its([:swift_account_number]) { is_expected.to eq('00000012810105723') }
       end
 
       context 'that has been zero-padded' do
         let(:account_number) { '000012810105723' }
 
-        its([:bank_code]) { is_expected.to eq('120') }
-        its([:account_number]) { is_expected.to eq('00000012810105723') }
+        its([:account_number]) { is_expected.to eq('0105723') }
+        its([:branch_code]) { is_expected.to eq('1281') }
+        its([:swift_bank_code]) { is_expected.to eq('120') }
+        its([:swift_account_number]) { is_expected.to eq('00000012810105723') }
       end
 
       context 'that needs the account number part to be zero-padded' do
         let(:account_number) { '1281-1' }
 
-        its([:bank_code]) { is_expected.to eq('120') }
-        its([:account_number]) { is_expected.to eq('00000000000012811') }
+        its([:account_number]) { is_expected.to eq('1') }
+        its([:branch_code]) { is_expected.to eq('1281') }
+        its([:swift_bank_code]) { is_expected.to eq('120') }
+        its([:swift_account_number]) { is_expected.to eq('00000000000012811') }
       end
 
       context 'from SEB' do
         let(:account_number) { '5439-10 240 39' }
 
-        its([:bank_code]) { is_expected.to eq('500') }
-        its([:account_number]) { is_expected.to eq('00000054391024039') }
+        its([:account_number]) { is_expected.to eq('1024039') }
+        its([:branch_code]) { is_expected.to eq('5439') }
+        its([:swift_bank_code]) { is_expected.to eq('500') }
+        its([:swift_account_number]) { is_expected.to eq('00000054391024039') }
       end
     end
 
     context "with a clearing code that doesn't match any banks" do
       let(:account_number) { '1001-1' }
 
-      its([:bank_code]) { is_expected.to eq(nil) }
-      its([:account_number]) { is_expected.to eq('00000000000010011') }
+      its([:account_number]) { is_expected.to eq(nil) }
+      its([:branch_code]) { is_expected.to eq(nil) }
+      its([:swift_bank_code]) { is_expected.to eq(nil) }
+      its([:swift_account_number]) { is_expected.to eq('00000000000010011') }
     end
 
     context 'with a Swedbank clearing code' do
       let(:account_number) { '7507-1211203' }
 
-      its([:bank_code]) { is_expected.to eq('800') }
-      its([:account_number]) { is_expected.to eq('00000075071211203') }
+      its([:account_number]) { is_expected.to eq('1211203') }
+      its([:branch_code]) { is_expected.to eq('7507') }
+      its([:swift_bank_code]) { is_expected.to eq('800') }
+      its([:swift_account_number]) { is_expected.to eq('00000075071211203') }
 
       context 'in the 8000s range' do
         let(:account_number) { '8327-9 33395390-9' }
 
-        its([:bank_code]) { is_expected.to eq('800') }
-        its([:account_number]) { is_expected.to eq('00832790333953909') }
+        its([:account_number]) { is_expected.to eq('0333953909') }
+        its([:branch_code]) { is_expected.to eq('83279') }
+        its([:swift_bank_code]) { is_expected.to eq('800') }
+        its([:swift_account_number]) { is_expected.to eq('00832790333953909') }
       end
 
       context 'another in the 8000s range' do
         let(:account_number) { '8201-6 914357963-0' }
 
-        its([:bank_code]) { is_expected.to eq('800') }
-        its([:account_number]) { is_expected.to eq('00820169143579630') }
+        its([:account_number]) { is_expected.to eq('9143579630') }
+        its([:branch_code]) { is_expected.to eq('82016') }
+        its([:swift_bank_code]) { is_expected.to eq('800') }
+        its([:swift_account_number]) { is_expected.to eq('00820169143579630') }
       end
     end
 
     context 'with a Sparbanken Öresund clearing code' do
       let(:account_number) { '9300-35299478' }
 
-      its([:bank_code]) { is_expected.to eq('930') }
-      its([:account_number]) { is_expected.to eq('00000000035299478') }
+      its([:account_number]) { is_expected.to eq('35299478') }
+      its([:branch_code]) { is_expected.to eq('9300') }
+      its([:swift_bank_code]) { is_expected.to eq('930') }
+      its([:swift_account_number]) { is_expected.to eq('00000000035299478') }
 
       context 'with clearing number 9330 or above' do
         let(:account_number) { '9330-5930160535' }
 
-        its([:bank_code]) { is_expected.to eq('933') }
-        its([:account_number]) { is_expected.to eq('00000005930160535') }
+        its([:account_number]) { is_expected.to eq('5930160535') }
+        its([:branch_code]) { is_expected.to eq('9330') }
+        its([:swift_bank_code]) { is_expected.to eq('933') }
+        its([:swift_account_number]) { is_expected.to eq('00000005930160535') }
       end
     end
 
     context 'with a Sparbanken Syd clearing code' do
       let(:account_number) { '9570-5250093407' }
 
-      its([:bank_code]) { is_expected.to eq('957') }
-      its([:account_number]) { is_expected.to eq('00000005250093407') }
+      its([:account_number]) { is_expected.to eq('5250093407') }
+      its([:branch_code]) { is_expected.to eq('9570') }
+      its([:swift_bank_code]) { is_expected.to eq('957') }
+      its([:swift_account_number]) { is_expected.to eq('00000005250093407') }
     end
 
     context 'with a Handelsbanken clearing code' do
       let(:account_number) { '6000-806967498' }
 
-      its([:bank_code]) { is_expected.to eq('600') }
-      its([:account_number]) { is_expected.to eq('00000000806967498') }
+      its([:account_number]) { is_expected.to eq('806967498') }
+      its([:branch_code]) { is_expected.to eq('6000') }
+      its([:swift_bank_code]) { is_expected.to eq('600') }
+      its([:swift_account_number]) { is_expected.to eq('00000000806967498') }
 
       context 'that has clearing code 6240' do
         let(:account_number) { '6240-219161038' }
 
-        its([:bank_code]) { is_expected.to eq('600') }
-        its([:account_number]) { is_expected.to eq('00000000219161038') }
+        its([:account_number]) { is_expected.to eq('219161038') }
+        its([:branch_code]) { is_expected.to eq('6240') }
+        its([:swift_bank_code]) { is_expected.to eq('600') }
+        its([:swift_account_number]) { is_expected.to eq('00000000219161038') }
       end
 
       context 'that only has an 8 digit serial number' do
         let(:account_number) { '6240-21916103' }
 
-        its([:bank_code]) { is_expected.to eq('600') }
-        its([:account_number]) { is_expected.to eq('00000000021916103') }
+        its([:account_number]) { is_expected.to eq('021916103') }
+        its([:branch_code]) { is_expected.to eq('6240') }
+        its([:swift_bank_code]) { is_expected.to eq('600') }
+        its([:swift_account_number]) { is_expected.to eq('00000000021916103') }
       end
     end
 
     context 'with a Nordea PlusGirot clearing code' do
       let(:account_number) { '9960-3401258276' }
 
-      its([:bank_code]) { is_expected.to eq('950') }
-      its([:account_number]) { is_expected.to eq('00099603401258276') }
+      its([:account_number]) { is_expected.to eq('3401258276') }
+      its([:branch_code]) { is_expected.to eq('9960') }
+      its([:swift_bank_code]) { is_expected.to eq('950') }
+      its([:swift_account_number]) { is_expected.to eq('00099603401258276') }
     end
   end
 


### PR DESCRIPTION
This PR does two things:

* Makes `swift_bank_code`, `swift_branch_code` and `swift_account_number` available on `IBAN`.  These return the same as their non-`swift` equivalents for most countries.
* In Sweden, return the clearing code and serial number as the `branch_code` and `account_number` respectively.  The bank code and account number as used in the IBAN can be found in `swift_bank_code` and `swift_account_number` respectively.

Other things to do (in future PRs):

* Allow constructing a Swedish IBAN from a `branch_code` and `account_number`.
* Generate and parse pseudo-IBANs for Sweden.

@isaacseymour, please could you take a look?