### PR TITLE
Create IBAN from Swedish details

### DIFF
--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -442,7 +442,7 @@ module Ibandit
 
     def self.clean_se_details(local_details)
       converted_details =
-        SwedishDetailsConverter.convert(local_details[:account_number])
+        SwedishDetailsConverter.new(local_details[:account_number]).convert
 
       bank_code = local_details[:bank_code] ||
                   converted_details[:swift_bank_code]

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -441,8 +441,10 @@ module Ibandit
     end
 
     def self.clean_se_details(local_details)
-      converted_details =
-        SwedishDetailsConverter.new(local_details[:account_number]).convert
+      converted_details = SwedishDetailsConverter.new(
+        branch_code: local_details[:branch_code],
+        account_number: local_details[:account_number]
+      ).convert
 
       bank_code = local_details[:bank_code] ||
                   converted_details[:swift_bank_code]

--- a/lib/ibandit/swedish_details_converter.rb
+++ b/lib/ibandit/swedish_details_converter.rb
@@ -1,35 +1,61 @@
 module Ibandit
-  module SwedishDetailsConverter
-    def self.convert(account_number)
-      cleaned_account_number =
-        account_number.gsub(/[-.\s]/, '').gsub(/\A0+/, '')
+  class SwedishDetailsConverter
+    def initialize(account_number)
+      @account_number = account_number
+    end
 
-      bank_info = bank_info_for(cleaned_account_number.slice(0, 4))
-
+    def convert
       if bank_info.nil?
         return { swift_bank_code: nil,
                  swift_account_number: cleaned_account_number.rjust(17, '0') }
       end
 
-      clearing_code_length = bank_info.fetch(:clearing_code_length)
-      serial_number_length = bank_info.fetch(:serial_number_length)
-
-      clearing_code = cleaned_account_number.slice(0, clearing_code_length)
-      serial_number = cleaned_account_number[clearing_code_length..-1]
-
-      if bank_info.fetch(:zerofill_serial_number)
-        serial_number = serial_number.rjust(serial_number_length, '0')
-      end
-
-      swift_account_number = build_swift_account_number(bank_info,
-                                                        clearing_code,
-                                                        serial_number)
       {
         account_number: serial_number,
         branch_code: clearing_code,
         swift_bank_code: bank_info.fetch(:bank_code).to_s,
         swift_account_number: swift_account_number
       }
+    end
+
+    private
+
+    def cleaned_account_number
+      @cleaned_account_number ||= @account_number.
+                                  gsub(/[-.\s]/, '').
+                                  gsub(/\A0+/, '')
+    end
+
+    def bank_info
+      @bank_info ||= self.class.bank_info_for(
+        cleaned_account_number.slice(0, 4))
+    end
+
+    def clearing_code_length
+      bank_info.fetch(:clearing_code_length)
+    end
+
+    def serial_number_length
+      bank_info.fetch(:serial_number_length)
+    end
+
+    def clearing_code
+      cleaned_account_number.slice(0, clearing_code_length)
+    end
+
+    def serial_number
+      serial_number = cleaned_account_number[clearing_code_length..-1]
+      return serial_number unless bank_info.fetch(:zerofill_serial_number)
+
+      serial_number.rjust(serial_number_length, '0')
+    end
+
+    def swift_account_number
+      if bank_info.fetch(:include_clearing_code)
+        (clearing_code + serial_number).rjust(17, '0')
+      else
+        serial_number.rjust(17, '0')
+      end
     end
 
     def self.valid_bank_code?(bank_code: nil, account_number: nil)
@@ -65,12 +91,9 @@ module Ibandit
       end
     end
 
-    private
-
     def self.bank_info_for(clearing_code)
       bank_info_table.find { |bank| bank[:range].include?(clearing_code.to_i) }
     end
-    private_class_method :bank_info_for
 
     def self.possible_bank_info_for(bank_code: nil, account_number: nil)
       clearing_number = account_number.gsub(/\A0+/, '').slice(0, 4).to_i
@@ -95,14 +118,5 @@ module Ibandit
         end
     end
     private_class_method :bank_info_table
-
-    def self.build_swift_account_number(bank_info, clearing_code, serial_number)
-      if bank_info.fetch(:include_clearing_code)
-        (clearing_code + serial_number).rjust(17, '0')
-      else
-        serial_number.rjust(17, '0')
-      end
-    end
-    private_class_method :build_swift_account_number
   end
 end

--- a/spec/ibandit/swedish_details_converter_spec.rb
+++ b/spec/ibandit/swedish_details_converter_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 
 describe Ibandit::SwedishDetailsConverter do
-  subject(:converter) { described_class.new(account_number) }
+  subject(:converter) do
+    described_class.new(account_number: account_number,
+                        branch_code: branch_code)
+  end
+
+  let(:branch_code) { nil }
 
   describe '.convert' do
     subject { converter.convert }
@@ -16,6 +21,16 @@ describe Ibandit::SwedishDetailsConverter do
 
       context 'that includes hyphens' do
         let(:account_number) { '1281-0105723' }
+
+        its([:account_number]) { is_expected.to eq('0105723') }
+        its([:branch_code]) { is_expected.to eq('1281') }
+        its([:swift_bank_code]) { is_expected.to eq('120') }
+        its([:swift_account_number]) { is_expected.to eq('00000012810105723') }
+      end
+
+      context 'with a separate branch code' do
+        let(:branch_code) { '1281' }
+        let(:account_number) { '0105723' }
 
         its([:account_number]) { is_expected.to eq('0105723') }
         its([:branch_code]) { is_expected.to eq('1281') }
@@ -66,6 +81,18 @@ describe Ibandit::SwedishDetailsConverter do
         its([:branch_code]) { is_expected.to eq('5439') }
         its([:swift_bank_code]) { is_expected.to eq('500') }
         its([:swift_account_number]) { is_expected.to eq('00000054391024039') }
+
+        context 'with a separate branch code' do
+          let(:branch_code) { '5439' }
+          let(:account_number) { '1024039' }
+
+          its([:account_number]) { is_expected.to eq('1024039') }
+          its([:branch_code]) { is_expected.to eq('5439') }
+          its([:swift_bank_code]) { is_expected.to eq('500') }
+          its([:swift_account_number]) do
+            is_expected.to eq('00000054391024039')
+          end
+        end
       end
     end
 
@@ -97,6 +124,16 @@ describe Ibandit::SwedishDetailsConverter do
 
       context 'another in the 8000s range' do
         let(:account_number) { '8201-6 914357963-0' }
+
+        its([:account_number]) { is_expected.to eq('9143579630') }
+        its([:branch_code]) { is_expected.to eq('82016') }
+        its([:swift_bank_code]) { is_expected.to eq('800') }
+        its([:swift_account_number]) { is_expected.to eq('00820169143579630') }
+      end
+
+      context 'with an explicit branch code' do
+        let(:branch_code) { '8201-6' }
+        let(:account_number) { '914357963-0' }
 
         its([:account_number]) { is_expected.to eq('9143579630') }
         its([:branch_code]) { is_expected.to eq('82016') }

--- a/spec/ibandit/swedish_details_converter_spec.rb
+++ b/spec/ibandit/swedish_details_converter_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 
 describe Ibandit::SwedishDetailsConverter do
+  subject(:converter) { described_class.new(account_number) }
+
   describe '.convert' do
-    subject { described_class.convert(account_number) }
+    subject { converter.convert }
 
     context 'with a type-1 account number' do
       let(:account_number) { '12810105723' }


### PR DESCRIPTION
Allows creating a Swedish IBAN from an `account_number` and `branch_code`.

Also includes a fairly chunky refactor of the `SwedishDetailsConverter` - might be best to review the first commit alone before looking at the rest.

@isaacseymour, please could you review?