### PR TITLE
Don't return local details from Swedish IBAN

### DIFF
--- a/lib/ibandit.rb
+++ b/lib/ibandit.rb
@@ -1,6 +1,7 @@
 require 'i18n'
 require 'ibandit/version'
 require 'ibandit/errors'
+require 'ibandit/constants'
 require 'ibandit/iban'
 require 'ibandit/german_details_converter'
 require 'ibandit/swedish_details_converter'

--- a/lib/ibandit/constants.rb
+++ b/lib/ibandit/constants.rb
@@ -1,0 +1,8 @@
+module Ibandit
+  module Constants
+    SUPPORTED_COUNTRY_CODES = %w(AT BE BG CY CZ DE DK EE ES FI FR GB GR HR HU IE
+                                 IS IT LT LU LV MC MT NL NO PL PT RO SE SI SK
+                                 SM).freeze
+    EXPLICIT_SWIFT_DETAILS_COUNTRY_CODES = %w(SE).freeze
+  end
+end

--- a/lib/ibandit/iban_assembler.rb
+++ b/lib/ibandit/iban_assembler.rb
@@ -1,9 +1,5 @@
 module Ibandit
   module IBANAssembler
-    SUPPORTED_COUNTRY_CODES = %w(AT BE BG CY CZ DE DK EE ES FI FR GB GR HR HU IE
-                                 IS IT LT LU LV MC MT NL NO PL PT RO SE SI SK
-                                 SM).freeze
-
     EXCEPTION_COUNTRY_CODES = %w(IT SM BE).freeze
 
     def self.assemble(local_details)
@@ -67,8 +63,11 @@ module Ibandit
     ##################
 
     def self.can_assemble?(local_details)
-      SUPPORTED_COUNTRY_CODES.include?(local_details[:country_code]) &&
-        valid_arguments?(local_details)
+      supported_country_code?(local_details) && valid_arguments?(local_details)
+    end
+
+    def self.supported_country_code?(local_details)
+      Constants::SUPPORTED_COUNTRY_CODES.include?(local_details[:country_code])
     end
 
     def self.valid_arguments?(local_details)

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -1,10 +1,5 @@
 module Ibandit
   module LocalDetailsCleaner
-    SUPPORTED_COUNTRY_CODES = %w(AT BE BG CY CZ DE DK EE ES FI FR GB GR HR HU IE
-                                 IS IT LT LU LV MC MT NL NO PL PT RO SE SI SK
-                                 SM).freeze
-    EXPLICIT_SWIFT_DETAILS_COUNTRY_CODES = %w(SE).freeze
-
     def self.clean(local_details)
       country_code = local_details[:country_code]
 
@@ -23,12 +18,12 @@ module Ibandit
     ###########
 
     def self.can_clean?(country_code, local_details)
-      SUPPORTED_COUNTRY_CODES.include?(country_code) &&
+      Constants::SUPPORTED_COUNTRY_CODES.include?(country_code) &&
         fields_for?(country_code, local_details)
     end
 
     def self.explicit_swift_details?(country_code)
-      EXPLICIT_SWIFT_DETAILS_COUNTRY_CODES.include?(country_code)
+      Constants::EXPLICIT_SWIFT_DETAILS_COUNTRY_CODES.include?(country_code)
     end
 
     def self.fields_for?(country_code, opts)

--- a/spec/ibandit/iban_assembler_spec.rb
+++ b/spec/ibandit/iban_assembler_spec.rb
@@ -6,9 +6,9 @@ describe Ibandit::IBANAssembler do
     let(:args) do
       {
         country_code:   iban.country_code,
-        account_number: iban.account_number,
-        branch_code:    iban.branch_code,
-        bank_code:      iban.bank_code
+        account_number: iban.swift_account_number,
+        branch_code:    iban.swift_branch_code,
+        bank_code:      iban.swift_bank_code
       }.reject { |_key, value| value.nil? }
     end
 

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -68,6 +68,21 @@ describe Ibandit::IBAN do
       its(:local_check_digits) { is_expected.to be_nil }
     end
 
+    context 'when local details are not available' do
+      let(:iban_code) { 'SE2680000000075071211203' }
+
+      its(:country_code) { is_expected.to eq('SE') }
+      its(:check_digits) { is_expected.to eq('26') }
+      its(:bank_code) { is_expected.to be_nil }
+      its(:branch_code) { is_expected.to be_nil }
+      its(:account_number) { is_expected.to be_nil }
+      its(:swift_bank_code) { is_expected.to eq('800') }
+      its(:swift_branch_code) { is_expected.to be_nil }
+      its(:swift_account_number) { is_expected.to eq('00000075071211203') }
+      its(:iban_national_id) { is_expected.to eq('800') }
+      its(:local_check_digits) { is_expected.to be_nil }
+    end
+
     context 'when the IBAN was created with local details' do
       let(:arg) do
         {


### PR DESCRIPTION
It's not possible to extract local details from a Swedish IBAN, so calling (e.g.) `iban.account_number` should return `nil` in that case (`iban.swift_account_number` is non-`nil`).

Fix this by explicitly setting local details (rather than defaulting them to the SWIFT details), except for Sweden.

@isaacseymour, please could you review?