### PR TITLE
Fill in SWIFT details after cleaning

### DIFF
--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -3,14 +3,14 @@ module Ibandit
     def self.clean(local_details)
       country_code = local_details[:country_code]
 
-      unless explicit_swift_details?(country_code)
-        local_details = swift_details_for(local_details).merge(local_details)
+      if can_clean?(country_code, local_details)
+        local_details = local_details.merge(
+          public_send(:"clean_#{country_code.downcase}_details", local_details))
       end
 
-      return local_details unless can_clean?(country_code, local_details)
+      return local_details if explicit_swift_details?(country_code)
 
-      local_details.merge(
-        public_send(:"clean_#{country_code.downcase}_details", local_details))
+      swift_details_for(local_details).merge(local_details)
     end
 
     ###########

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -375,6 +375,7 @@ describe Ibandit::LocalDetailsCleaner do
     context 'with the sort code is hyphenated' do
       let(:branch_code) { '20-00-00' }
       its([:branch_code]) { is_expected.to eq('200000') }
+      its([:swift_branch_code]) { is_expected.to eq('200000') }
     end
 
     context 'with the sort code spaced' do
@@ -385,6 +386,7 @@ describe Ibandit::LocalDetailsCleaner do
     context 'with a short account number' do
       let(:account_number) { '579135' }
       its([:account_number]) { is_expected.to eq('00579135') }
+      its([:swift_account_number]) { is_expected.to eq('00579135') }
     end
 
     context 'with a too-short account number' do
@@ -421,6 +423,7 @@ describe Ibandit::LocalDetailsCleaner do
         after { Ibandit.bic_finder = nil }
 
         its([:bank_code]) { is_expected.to eq('BARC') }
+        its([:swift_bank_code]) { is_expected.to eq('BARC') }
       end
     end
 


### PR DESCRIPTION
Previously, the cleaner would add the SWIFT details to the hash, then clean the local details.  This meant that the SWIFT details were always the uncleaned version.

This PR reverses the order of these two steps, to make sure that `swift_branch_code` et al have been cleaned first.  Fixes spec failures in modulus_check.

@isaacseymour, please could you review?