### PR TITLE
Allow spaces in Spanish account number

### DIFF
--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -191,9 +191,10 @@ module Ibandit
       if local_details[:bank_code] && local_details[:branch_code]
         bank_code      = local_details[:bank_code]
         branch_code    = local_details[:branch_code]
-        account_number = local_details[:account_number]
+        account_number = local_details[:account_number].gsub(/[-\s]/, '')
       else
-        cleaned_account_number = local_details[:account_number].tr('-', '')
+        cleaned_account_number =
+          local_details[:account_number].gsub(/[-\s]/, '')
 
         bank_code      = cleaned_account_number.slice(0, 4)
         branch_code    = cleaned_account_number.slice(4, 4)

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -305,6 +305,11 @@ describe Ibandit::LocalDetailsCleaner do
       its([:account_number]) { is_expected.to eq('180000012345') }
     end
 
+    context 'with spaces in the account number' do
+      let(:account_number) { '18 0000012345' }
+      its([:account_number]) { is_expected.to eq('180000012345') }
+    end
+
     context 'without an account number' do
       let(:account_number) { nil }
       it { is_expected.to eq(local_details_with_swift) }


### PR DESCRIPTION
Spanish account numbers are often expressed as `XX XXXXXXXXXX`, where the first two digits are the check digit.