### PR TITLE
Support branch code modulus checks

### DIFF
--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -243,7 +243,9 @@ module Ibandit
       return unless valid_format?
       return true unless Ibandit.modulus_checker
 
-      valid_modulus_check_bank_code? && valid_modulus_check_account_number?
+      valid_modulus_check_bank_code? &&
+        valid_modulus_check_branch_code? &&
+        valid_modulus_check_account_number?
     end
 
     def passes_country_specific_checks?
@@ -385,7 +387,14 @@ module Ibandit
     def valid_modulus_check_bank_code?
       return true if Ibandit.modulus_checker.valid_bank_code?(iban.to_s)
 
-      @errors[modulus_check_bank_code_field] = Ibandit.translate(:is_invalid)
+      @errors[:bank_code] = Ibandit.translate(:is_invalid)
+      false
+    end
+
+    def valid_modulus_check_branch_code?
+      return true if Ibandit.modulus_checker.valid_branch_code?(iban.to_s)
+
+      @errors[:branch_code] = Ibandit.translate(:is_invalid)
       false
     end
 
@@ -394,15 +403,6 @@ module Ibandit
 
       @errors[:account_number] = Ibandit.translate(:is_invalid)
       false
-    end
-
-    def modulus_check_bank_code_field
-      if LocalDetailsCleaner.required_fields(country_code).
-         include?(:branch_code)
-        :branch_code
-      else
-        :bank_code
-      end
     end
 
     def swift_details

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -1137,6 +1137,7 @@ describe Ibandit::IBAN do
       before do
         Ibandit.modulus_checker = double(
           valid_bank_code?: valid_bank_code,
+          valid_branch_code?: valid_branch_code,
           valid_account_number?: valid_account_number)
       end
       after { Ibandit.modulus_checker = nil }
@@ -1145,6 +1146,7 @@ describe Ibandit::IBAN do
       context 'with an invalid bank code' do
         let(:iban_code) { 'AT611904300234573201' }
         let(:valid_bank_code) { false }
+        let(:valid_branch_code) { true }
         let(:valid_account_number) { true }
 
         it { is_expected.to be(false) }
@@ -1177,60 +1179,64 @@ describe Ibandit::IBAN do
         context 'locale nl', locale: :nl do
           specify { expect(iban.errors).to include(bank_code: 'is ongeldig') }
         end
+      end
 
-        context 'when the bank code is not required' do
-          let(:iban_code) { 'GB60BARC20000055779911' }
-          before { Ibandit.bic_finder = double(call: 'BARCGB22XXX') }
-          after { Ibandit.bic_finder = nil }
-          before { iban.valid_local_modulus_check? }
+      context 'with an invalid branch code' do
+        let(:iban_code) { 'GB60BARC20000055779911' }
+        before { Ibandit.bic_finder = double(call: 'BARCGB22XXX') }
+        after { Ibandit.bic_finder = nil }
+        before { iban.valid_local_modulus_check? }
+        let(:valid_bank_code) { true }
+        let(:valid_branch_code) { false }
+        let(:valid_account_number) { true }
 
-          it { is_expected.to be(false) }
-          context 'locale en', locale: :en do
-            specify do
-              expect(iban.errors).to include(branch_code: 'is invalid')
-            end
+        it { is_expected.to be(false) }
+        context 'locale en', locale: :en do
+          specify do
+            expect(iban.errors).to include(branch_code: 'is invalid')
           end
+        end
 
-          context 'locale fr', locale: :fr do
-            specify do
-              expect(iban.errors).to include(branch_code: 'est invalide')
-            end
+        context 'locale fr', locale: :fr do
+          specify do
+            expect(iban.errors).to include(branch_code: 'est invalide')
           end
+        end
 
-          context 'locale de', locale: :de do
-            specify do
-              expect(iban.errors).to include(branch_code: 'ist nicht gültig')
-            end
+        context 'locale de', locale: :de do
+          specify do
+            expect(iban.errors).to include(branch_code: 'ist nicht gültig')
           end
+        end
 
-          context 'locale pt', locale: :pt do
-            specify do
-              expect(iban.errors).to include(branch_code: 'é inválido')
-            end
+        context 'locale pt', locale: :pt do
+          specify do
+            expect(iban.errors).to include(branch_code: 'é inválido')
           end
+        end
 
-          context 'locale es', locale: :es do
-            specify do
-              expect(iban.errors).to include(branch_code: 'es inválido')
-            end
+        context 'locale es', locale: :es do
+          specify do
+            expect(iban.errors).to include(branch_code: 'es inválido')
           end
+        end
 
-          context 'locale it', locale: :it do
-            specify do
-              expect(iban.errors).to include(branch_code: 'non è valido')
-            end
+        context 'locale it', locale: :it do
+          specify do
+            expect(iban.errors).to include(branch_code: 'non è valido')
           end
+        end
 
-          context 'locale nl', locale: :nl do
-            specify do
-              expect(iban.errors).to include(branch_code: 'is ongeldig')
-            end
+        context 'locale nl', locale: :nl do
+          specify do
+            expect(iban.errors).to include(branch_code: 'is ongeldig')
           end
         end
       end
 
       context 'with an invalid account number' do
         let(:valid_bank_code) { true }
+        let(:valid_branch_code) { true }
         let(:valid_account_number) { false }
 
         it { is_expected.to be(false) }


### PR DESCRIPTION
Currently we use the `valid_modulus_check_bank_code?` method to check either the branch code or the bank code. That's a bit grim - we should let the integrator decide what they want to do with each of these hooks.