### PR TITLE
Pass IBAN object to checker instead of IBAN string

### DIFF
--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -385,21 +385,21 @@ module Ibandit
     end
 
     def valid_modulus_check_bank_code?
-      return true if Ibandit.modulus_checker.valid_bank_code?(iban.to_s)
+      return true if Ibandit.modulus_checker.valid_bank_code?(self)
 
       @errors[:bank_code] = Ibandit.translate(:is_invalid)
       false
     end
 
     def valid_modulus_check_branch_code?
-      return true if Ibandit.modulus_checker.valid_branch_code?(iban.to_s)
+      return true if Ibandit.modulus_checker.valid_branch_code?(self)
 
       @errors[:branch_code] = Ibandit.translate(:is_invalid)
       false
     end
 
     def valid_modulus_check_account_number?
-      return true if Ibandit.modulus_checker.valid_account_number?(iban.to_s)
+      return true if Ibandit.modulus_checker.valid_account_number?(self)
 
       @errors[:account_number] = Ibandit.translate(:is_invalid)
       false

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -1149,7 +1149,16 @@ describe Ibandit::IBAN do
         let(:valid_branch_code) { true }
         let(:valid_account_number) { true }
 
+        it 'calls valid_bank_code? with an IBAN object' do
+          expect(Ibandit.modulus_checker).
+            to receive(:valid_bank_code?).
+            with(instance_of(Ibandit::IBAN))
+
+          iban.valid_local_modulus_check?
+        end
+
         it { is_expected.to be(false) }
+
         context 'locale en', locale: :en do
           specify { expect(iban.errors).to include(bank_code: 'is invalid') }
         end
@@ -1190,7 +1199,16 @@ describe Ibandit::IBAN do
         let(:valid_branch_code) { false }
         let(:valid_account_number) { true }
 
+        it 'calls valid_branch_code? with an IBAN object' do
+          expect(Ibandit.modulus_checker).
+            to receive(:valid_branch_code?).
+            with(instance_of(Ibandit::IBAN))
+
+          iban.valid_local_modulus_check?
+        end
+
         it { is_expected.to be(false) }
+
         context 'locale en', locale: :en do
           specify do
             expect(iban.errors).to include(branch_code: 'is invalid')
@@ -1239,7 +1257,16 @@ describe Ibandit::IBAN do
         let(:valid_branch_code) { true }
         let(:valid_account_number) { false }
 
+        it 'calls valid_account_number? with an IBAN object' do
+          expect(Ibandit.modulus_checker).
+            to receive(:valid_account_number?).
+            with(instance_of(Ibandit::IBAN))
+
+          iban.valid_local_modulus_check?
+        end
+
         it { is_expected.to be(false) }
+
         context 'locale en', locale: :en do
           specify do
             expect(iban.errors).to include(account_number: 'is invalid')


### PR DESCRIPTION
Important when the IBAN is a pseudo-iban.