### PR TITLE
Rename iban_national_id to swift_national_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ county combines them:
 `swift_account_number`
 :    The account number for the account
 
-`iban_national_id`
+`swift_national_id`
 :    The national ID for the bank / branch as documented by SWIFT
 
 The SWIFT IBAN components are all available as methods on an `IBAN` object:
@@ -119,7 +119,7 @@ iban.check_digits              # => "82"
 iban.swift_bank_code           # => "WEST"
 iban.swift_branch_code         # => "123456"
 iban.swift_account_number      # => "98765432"
-iban.iban_national_id          # => "WEST123456"
+iban.swift_national_id          # => "WEST123456"
 ```
 
 In addition, it is often useful to extract any local check digits from the IBAN.

--- a/bin/build_structure_file.rb
+++ b/bin/build_structure_file.rb
@@ -16,7 +16,7 @@ class Country
   element 'account_number_position', as: :account_number_position
   element 'account_number_length', as: :account_number_length
   element 'iban_total_length', as: :total_length
-  element 'iban_national_id_length', as: :iban_national_id_length
+  element 'iban_national_id_length', as: :national_id_length
 end
 
 class Report
@@ -37,7 +37,7 @@ def get_iban_structures(iban_structures_file, iban_registry_file)
       account_number_position: country.account_number_position.to_i,
       account_number_length: country.account_number_length.to_i,
       total_length: country.total_length.to_i,
-      iban_national_id_length: country.iban_national_id_length.to_i
+      national_id_length: country.national_id_length.to_i
     }.merge(bban_formats[country.country_code])
   end
 end

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -7,7 +7,7 @@ AD:
   :account_number_position: 13
   :account_number_length: 12
   :total_length: 24
-  :iban_national_id_length: 8
+  :national_id_length: 8
   :bban_format: \d{4}\d{4}[A-Z0-9]{12}
   :bank_code_format: \d{4}
   :branch_code_format: \d{4}
@@ -20,7 +20,7 @@ AE:
   :account_number_position: 8
   :account_number_length: 16
   :total_length: 23
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{3}\d{16}
   :bank_code_format: \d{3}
   :account_number_format: \d{16}
@@ -32,7 +32,7 @@ AL:
   :account_number_position: 13
   :account_number_length: 16
   :total_length: 28
-  :iban_national_id_length: 8
+  :national_id_length: 8
   :bban_format: \d{8}[A-Z0-9]{16}
   :bank_code_format: \d{3}
   :account_number_format: '[A-Z0-9]{16}'
@@ -45,7 +45,7 @@ AT:
   :account_number_position: 10
   :account_number_length: 11
   :total_length: 20
-  :iban_national_id_length: 5
+  :national_id_length: 5
   :bban_format: \d{5}\d{11}
   :bank_code_format: \d{5}
   :account_number_format: \d{11}
@@ -57,7 +57,7 @@ AZ:
   :account_number_position: 9
   :account_number_length: 20
   :total_length: 28
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z]{4}[A-Z0-9]{20}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: '[A-Z0-9]{20}'
@@ -69,7 +69,7 @@ BA:
   :account_number_position: 11
   :account_number_length: 10
   :total_length: 20
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{3}\d{3}\d{8}\d{2}
   :bank_code_format: \d{3}
   :branch_code_format: \d{3}
@@ -82,7 +82,7 @@ BE:
   :account_number_position: 5
   :account_number_length: 12
   :total_length: 16
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{3}\d{7}\d{2}
   :bank_code_format: \d{3}
   :account_number_format: \d{7}\d{2}
@@ -96,7 +96,7 @@ BG:
   :account_number_position: 13
   :account_number_length: 10
   :total_length: 22
-  :iban_national_id_length: 8
+  :national_id_length: 8
   :bban_format: '[A-Z]{4}\d{4}\d{2}[A-Z0-9]{8}'
   :bank_code_format: '[A-Z]{4}'
   :branch_code_format: \d{4}
@@ -109,7 +109,7 @@ BH:
   :account_number_position: 9
   :account_number_length: 14
   :total_length: 22
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z]{4}[A-Z0-9]{14}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: '[A-Z0-9]{14}'
@@ -121,7 +121,7 @@ BR:
   :account_number_position: 18
   :account_number_length: 12
   :total_length: 29
-  :iban_national_id_length: 8
+  :national_id_length: 8
   :bban_format: \d{8}\d{5}\d{10}[A-Z]{1}[A-Z0-9]{1}
   :bank_code_format: \d{8}
   :account_number_format: \d{10}[A-Z]{1}[A-Z0-9]{1}
@@ -134,7 +134,7 @@ CH:
   :account_number_position: 10
   :account_number_length: 12
   :total_length: 21
-  :iban_national_id_length: 5
+  :national_id_length: 5
   :bban_format: \d{5}[A-Z0-9]{12}
   :bank_code_format: \d{5}
   :account_number_format: '[A-Z0-9]{12}'
@@ -146,7 +146,7 @@ CR:
   :account_number_position: 8
   :account_number_length: 14
   :total_length: 21
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{3}\d{14}
   :bank_code_format: \d{3}
   :account_number_format: \d{14}
@@ -158,7 +158,7 @@ CY:
   :account_number_position: 13
   :account_number_length: 16
   :total_length: 28
-  :iban_national_id_length: 8
+  :national_id_length: 8
   :bban_format: \d{3}\d{5}[A-Z0-9]{16}
   :bank_code_format: \d{3}
   :branch_code_format: \d{5}
@@ -171,7 +171,7 @@ CZ:
   :account_number_position: 9
   :account_number_length: 16
   :total_length: 24
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: \d{4}\d{6}\d{10}
   :bank_code_format: \d{4}
   :account_number_format: \d{6}\d{10}
@@ -183,7 +183,7 @@ DE:
   :account_number_position: 13
   :account_number_length: 10
   :total_length: 22
-  :iban_national_id_length: 8
+  :national_id_length: 8
   :bban_format: \d{8}\d{10}
   :bank_code_format: \d{8}
   :account_number_format: \d{10}
@@ -195,7 +195,7 @@ DK:
   :account_number_position: 9
   :account_number_length: 10
   :total_length: 18
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: \d{4}\d{9}\d{1}
   :bank_code_format: \d{4}
   :account_number_format: \d{9}\d{1}
@@ -207,7 +207,7 @@ DO:
   :account_number_position: 9
   :account_number_length: 20
   :total_length: 28
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z0-9]{4}\d{20}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: '{4}\d{20}'
@@ -219,7 +219,7 @@ EE:
   :account_number_position: 7
   :account_number_length: 14
   :total_length: 20
-  :iban_national_id_length: 2
+  :national_id_length: 2
   :bban_format: \d{2}\d{2}\d{11}\d{1}
   :bank_code_format: '[1-9][0-9]'
   :account_number_format: \d{2}\d{11}\d{1}
@@ -233,7 +233,7 @@ ES:
   :account_number_position: 13
   :account_number_length: 12
   :total_length: 24
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: \d{4}\d{4}\d{1}\d{1}\d{10}
   :bank_code_format: \d{4}
   :branch_code_format: \d{4}
@@ -248,7 +248,7 @@ FI:
   :account_number_position: 11
   :account_number_length: 8
   :total_length: 18
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{6}\d{7}\d{1}
   :bank_code_format: \d{6}
   :account_number_format: \d{7}\d{1}
@@ -262,7 +262,7 @@ FO:
   :account_number_position: 9
   :account_number_length: 10
   :total_length: 18
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: \d{4}\d{9}\d{1}
   :bank_code_format: \d{4}
   :account_number_format: \d{9}\d{1}
@@ -274,7 +274,7 @@ FR:
   :account_number_position: 15
   :account_number_length: 13
   :total_length: 27
-  :iban_national_id_length: 10
+  :national_id_length: 10
   :bban_format: \d{5}\d{5}[A-Z0-9]{11}\d{2}
   :bank_code_format: \d{5}
   :account_number_format: '[A-Z0-9]{11}\d{2}'
@@ -289,7 +289,7 @@ GB:
   :account_number_position: 15
   :account_number_length: 8
   :total_length: 22
-  :iban_national_id_length: 10
+  :national_id_length: 10
   :bban_format: '[A-Z]{4}\d{6}\d{8}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: \d{8}
@@ -302,7 +302,7 @@ GE:
   :account_number_position: 7
   :account_number_length: 16
   :total_length: 22
-  :iban_national_id_length: 2
+  :national_id_length: 2
   :bban_format: '[A-Z]{2}\d{16}'
   :bank_code_format: '[A-Z]{2}'
   :account_number_format: \d{16}
@@ -314,7 +314,7 @@ GI:
   :account_number_position: 9
   :account_number_length: 15
   :total_length: 23
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z]{4}[A-Z0-9]{15}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: '[A-Z0-9]{15}'
@@ -326,7 +326,7 @@ GL:
   :account_number_position: 9
   :account_number_length: 10
   :total_length: 18
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: \d{4}\d{9}\d{1}
   :bank_code_format: \d{4}
   :account_number_format: \d{9}\d{1}
@@ -338,7 +338,7 @@ GR:
   :account_number_position: 12
   :account_number_length: 16
   :total_length: 27
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{3}\d{4}[A-Z0-9]{16}
   :bank_code_format: \d{3}
   :branch_code_format: \d{4}
@@ -351,7 +351,7 @@ GT:
   :account_number_position: 9
   :account_number_length: 20
   :total_length: 28
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z0-9]{4}[A-Z0-9]{20}'
   :bank_code_format: '[A-Z0-9]{4}'
   :account_number_format: '[A-Z0-9]{20}'
@@ -363,7 +363,7 @@ HR:
   :account_number_position: 12
   :account_number_length: 10
   :total_length: 21
-  :iban_national_id_length: 7
+  :national_id_length: 7
   :bban_format: \d{7}\d{10}
   :bank_code_format: \d{7}
   :account_number_format: \d{10}
@@ -375,7 +375,7 @@ HU:
   :account_number_position: 12
   :account_number_length: 17
   :total_length: 28
-  :iban_national_id_length: 7
+  :national_id_length: 7
   :bban_format: \d{3}\d{4}\d{1}\d{15}\d{1}
   :bank_code_format: \d{3}
   :branch_code_format: \d{4}
@@ -388,7 +388,7 @@ IE:
   :account_number_position: 15
   :account_number_length: 8
   :total_length: 22
-  :iban_national_id_length: 10
+  :national_id_length: 10
   :bban_format: '[A-Z]{4}\d{6}\d{8}'
   :bank_code_format: '[A-Z]{4}'
   :branch_code_format: \d{6}
@@ -401,7 +401,7 @@ IL:
   :account_number_position: 11
   :account_number_length: 13
   :total_length: 23
-  :iban_national_id_length: 6
+  :national_id_length: 6
   :bban_format: \d{3}\d{3}\d{13}
   :bank_code_format: \d{3}
   :branch_code_format: \d{3}
@@ -414,7 +414,7 @@ IS:
   :account_number_position: 9
   :account_number_length: 18
   :total_length: 26
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: \d{4}\d{2}\d{6}\d{10}
   :bank_code_format: \d{4}
   :account_number_format: \d{2}\d{6}\d{10}
@@ -428,7 +428,7 @@ IT:
   :account_number_position: 16
   :account_number_length: 12
   :total_length: 27
-  :iban_national_id_length: 10
+  :national_id_length: 10
   :bban_format: '[A-Z]{1}\d{5}\d{5}[A-Z0-9]{12}'
   :bank_code_format: \d{5}
   :branch_code_format: \d{5}
@@ -443,7 +443,7 @@ KW:
   :account_number_position: 9
   :account_number_length: 22
   :total_length: 30
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z]{4}[A-Z0-9]{22}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: '[A-Z0-9]{22}'
@@ -455,7 +455,7 @@ KZ:
   :account_number_position: 8
   :account_number_length: 13
   :total_length: 20
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{3}[A-Z0-9]{13}
   :bank_code_format: \d{3}
   :account_number_format: '[A-Z0-9]{13}'
@@ -467,7 +467,7 @@ LB:
   :account_number_position: 14
   :account_number_length: 14
   :total_length: 28
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: \d{4}[A-Z0-9]{20}
   :bank_code_format: \d{4}
   :account_number_format: '[A-Z0-9]{14}'
@@ -479,7 +479,7 @@ LI:
   :account_number_position: 10
   :account_number_length: 12
   :total_length: 21
-  :iban_national_id_length: 5
+  :national_id_length: 5
   :bban_format: \d{5}[A-Z0-9]{12}
   :bank_code_format: \d{5}
   :account_number_format: '[A-Z0-9]{12}'
@@ -491,7 +491,7 @@ LT:
   :account_number_position: 10
   :account_number_length: 11
   :total_length: 20
-  :iban_national_id_length: 5
+  :national_id_length: 5
   :bban_format: \d{5}\d{11}
   :bank_code_format: \d{5}
   :account_number_format: \d{11}
@@ -503,7 +503,7 @@ LU:
   :account_number_position: 8
   :account_number_length: 13
   :total_length: 20
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{3}[A-Z0-9]{13}
   :bank_code_format: \d{3}
   :account_number_format: '[A-Z0-9]{13}'
@@ -515,7 +515,7 @@ LV:
   :account_number_position: 9
   :account_number_length: 13
   :total_length: 21
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z]{4}[A-Z0-9]{13}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: '[A-Z0-9]{13}'
@@ -527,7 +527,7 @@ MC:
   :account_number_position: 15
   :account_number_length: 13
   :total_length: 27
-  :iban_national_id_length: 10
+  :national_id_length: 10
   :bban_format: \d{5}\d{5}[A-Z0-9]{11}\d{2}
   :bank_code_format: \d{5}
   :branch_code_format: \d{5}
@@ -542,7 +542,7 @@ MD:
   :account_number_position: 7
   :account_number_length: 18
   :total_length: 24
-  :iban_national_id_length: 2
+  :national_id_length: 2
   :bban_format: '[A-Z0-9]{2}[A-Z0-9]{18}'
   :bank_code_format: '[A-Z0-9]{2}'
   :account_number_format: '[A-Z0-9]{18}'
@@ -554,7 +554,7 @@ ME:
   :account_number_position: 8
   :account_number_length: 15
   :total_length: 22
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{3}\d{13}\d{2}
   :bank_code_format: \d{3}
   :account_number_format: \d{13}\d{2}
@@ -566,7 +566,7 @@ MK:
   :account_number_position: 8
   :account_number_length: 12
   :total_length: 19
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{3}[A-Z0-9]{10}\d{2}
   :bank_code_format: \d{3}
   :account_number_format: '[A-Z0-9]{10}\d{2}'
@@ -578,7 +578,7 @@ MR:
   :account_number_position: 15
   :account_number_length: 13
   :total_length: 27
-  :iban_national_id_length: 10
+  :national_id_length: 10
   :bban_format: \d{5}\d{5}\d{11}\d{2}
   :bank_code_format: \d{5}
   :branch_code_format: \d{5}
@@ -591,7 +591,7 @@ MT:
   :account_number_position: 14
   :account_number_length: 18
   :total_length: 31
-  :iban_national_id_length: 9
+  :national_id_length: 9
   :bban_format: '[A-Z]{4}\d{5}[A-Z0-9]{18}'
   :bank_code_format: '[A-Z]{4}'
   :branch_code_format: \d{5}
@@ -604,7 +604,7 @@ MU:
   :account_number_position: 13
   :account_number_length: 18
   :total_length: 30
-  :iban_national_id_length: 8
+  :national_id_length: 8
   :bban_format: '[A-Z]{4}\d{2}\d{2}\d{12}\d{3}[A-Z]{3}'
   :bank_code_format: '[A-Z]{4}\d{2}'
   :branch_code_format: \d{2}
@@ -617,7 +617,7 @@ NL:
   :account_number_position: 9
   :account_number_length: 10
   :total_length: 18
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z]{4}\d{10}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: \d{10}
@@ -631,7 +631,7 @@ NL:
   :account_number_position: 9
   :account_number_length: 7
   :total_length: 15
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: \d{4}\d{6}\d{1}
   :bank_code_format: \d{4}
   :account_number_format: \d{6}\d{1}
@@ -645,7 +645,7 @@ PK:
   :account_number_position: 9
   :account_number_length: 16
   :total_length: 24
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z]{4}[A-Z0-9]{16}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: '[A-Z0-9]{16}'
@@ -657,7 +657,7 @@ PL:
   :account_number_position: 13
   :account_number_length: 16
   :total_length: 28
-  :iban_national_id_length: 8
+  :national_id_length: 8
   :bban_format: \d{8}\d{16}
   :bank_code_format: \d{8}
   :account_number_format: \d{16}
@@ -669,7 +669,7 @@ PS:
   :account_number_position: 9
   :account_number_length: 21
   :total_length: 29
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z]{4}[A-Z0-9]{21}'
   :bank_code_format: '4'
   :account_number_format: '}[A-Z0-9]{21}'
@@ -681,7 +681,7 @@ PT:
   :account_number_position: 13
   :account_number_length: 13
   :total_length: 25
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: \d{4}\d{4}\d{11}\d{2}
   :bank_code_format: \d{4}
   :account_number_format: \d{11}\d{2}
@@ -696,7 +696,7 @@ RO:
   :account_number_position: 9
   :account_number_length: 16
   :total_length: 24
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z]{4}[A-Z0-9]{16}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: '[A-Z0-9]{16}'
@@ -708,7 +708,7 @@ RS:
   :account_number_position: 8
   :account_number_length: 15
   :total_length: 22
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{3}\d{13}\d{2}
   :bank_code_format: \d{3}
   :account_number_format: \d{13}\d{2}
@@ -720,7 +720,7 @@ SA:
   :account_number_position: 7
   :account_number_length: 18
   :total_length: 24
-  :iban_national_id_length: 2
+  :national_id_length: 2
   :bban_format: \d{2}[A-Z0-9]{18}
   :bank_code_format: \d{2}
   :account_number_format: '[A-Z0-9]{18}'
@@ -732,7 +732,7 @@ SE:
   :account_number_position: 8
   :account_number_length: 17
   :total_length: 24
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{3}\d{16}\d{1}
   :bank_code_format: \d{3}
   :account_number_format: \d{16}\d{1}
@@ -747,7 +747,7 @@ SI:
   :account_number_position: 10
   :account_number_length: 10
   :total_length: 19
-  :iban_national_id_length: 2
+  :national_id_length: 2
   :bban_format: \d{5}\d{8}\d{2}
   :bank_code_format: \d{5}
   :account_number_format: \d{8}\d{2}
@@ -759,7 +759,7 @@ SK:
   :account_number_position: 9
   :account_number_length: 16
   :total_length: 24
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: \d{4}\d{6}\d{10}
   :bank_code_format: \d{4}
   :account_number_format: \d{6}\d{10}
@@ -773,7 +773,7 @@ SM:
   :account_number_position: 16
   :account_number_length: 12
   :total_length: 27
-  :iban_national_id_length: 10
+  :national_id_length: 10
   :bban_format: '[A-Z]{1}\d{5}\d{5}[A-Z0-9]{12}'
   :bank_code_format: \d{5}
   :branch_code_format: \d{5}
@@ -788,7 +788,7 @@ TN:
   :account_number_position: 10
   :account_number_length: 15
   :total_length: 24
-  :iban_national_id_length: 2
+  :national_id_length: 2
   :bban_format: \d{2}\d{3}\d{13}\d{2}
   :bank_code_format: \d{2}
   :branch_code_format: \d{3}
@@ -801,7 +801,7 @@ TR:
   :account_number_position: 10
   :account_number_length: 17
   :total_length: 26
-  :iban_national_id_length: 5
+  :national_id_length: 5
   :bban_format: \d{5}[A-Z0-9]{1}[A-Z0-9]{16}
   :bank_code_format: \d{5}
   :account_number_format: '[A-Z0-9]{1}[A-Z0-9]{16}'
@@ -813,7 +813,7 @@ VG:
   :account_number_position: 9
   :account_number_length: 16
   :total_length: 24
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z]{4}\d{16}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: \d{16}
@@ -825,7 +825,7 @@ JO:
   :account_number_position: 9
   :account_number_length: 22
   :total_length: 30
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z]{4}\d{4}[A-Z0-9]{18}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: \d{4}[A-Z0-9]{18}
@@ -837,7 +837,7 @@ QA:
   :account_number_position: 9
   :account_number_length: 21
   :total_length: 29
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: '[A-Z]{4}[A-Z0-9]{21}'
   :bank_code_format: '[A-Z]{4}'
   :account_number_format: '[A-Z0-9]{21}'
@@ -849,7 +849,7 @@ XK:
   :account_number_position: 5
   :account_number_length: 16
   :total_length: 20
-  :iban_national_id_length: 4
+  :national_id_length: 4
   :bban_format: \d{4}\d{10}\d{2}
   :bank_code_format: \d{4}
   :account_number_format: \d{10}\d{2}
@@ -861,7 +861,7 @@ TL:
   :account_number_position: 8
   :account_number_length: 16
   :total_length: 23
-  :iban_national_id_length: 3
+  :national_id_length: 3
   :bban_format: \d{3}\d{14}\d{2}
   :bank_code_format: \d{3}
   :account_number_format: ' \d{14} \d{2}'

--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -38,12 +38,12 @@ module Ibandit
     # Component parts #
     ###################
 
-    def iban_national_id
+    def swift_national_id
       return unless decomposable?
 
       national_id = swift_bank_code.to_s
       national_id += swift_branch_code.to_s
-      national_id.slice(0, structure[:iban_national_id_length])
+      national_id.slice(0, structure[:national_id_length])
     end
 
     def local_check_digits

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -52,7 +52,7 @@ describe Ibandit::IBAN do
     its(:swift_bank_code) { is_expected.to eq('WEST') }
     its(:swift_branch_code) { is_expected.to eq('123456') }
     its(:swift_account_number) { is_expected.to eq('98765432') }
-    its(:iban_national_id) { is_expected.to eq('WEST123456') }
+    its(:swift_national_id) { is_expected.to eq('WEST123456') }
     its(:local_check_digits) { is_expected.to be_nil }
 
     context 'when the IBAN is blank' do
@@ -63,7 +63,7 @@ describe Ibandit::IBAN do
       its(:bank_code) { is_expected.to be_nil }
       its(:branch_code) { is_expected.to be_nil }
       its(:account_number) { is_expected.to be_nil }
-      its(:iban_national_id) { is_expected.to be_nil }
+      its(:swift_national_id) { is_expected.to be_nil }
       its(:bban) { is_expected.to be_nil }
       its(:local_check_digits) { is_expected.to be_nil }
     end
@@ -79,7 +79,7 @@ describe Ibandit::IBAN do
       its(:swift_bank_code) { is_expected.to eq('800') }
       its(:swift_branch_code) { is_expected.to be_nil }
       its(:swift_account_number) { is_expected.to eq('00000075071211203') }
-      its(:iban_national_id) { is_expected.to eq('800') }
+      its(:swift_national_id) { is_expected.to eq('800') }
       its(:local_check_digits) { is_expected.to be_nil }
     end
 


### PR DESCRIPTION
This ID comes from SWIFT. Its relationship to the IBAN in implicit.

This is a breaking change - to accommodate it, replace any use of `iban_national_id` in your code with `swift_national_id`.