### PR TITLE
Avoid crashing on certain very short inputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,11 @@ language: ruby
 
 matrix:
   allow_failures:
-    - rvm: jruby
-    - rvm: rbx-2
 
 rvm:
-  - 2.0
   - 2.1
   - 2.2
   - 2.3.0
-  - jruby
-  - rbx-2
 
 sudo: false
 

--- a/lib/ibandit/sweden/local_details_converter.rb
+++ b/lib/ibandit/sweden/local_details_converter.rb
@@ -76,15 +76,15 @@ module Ibandit
                         end
 
         return serial_number unless bank_info.fetch(:zerofill_serial_number)
-
-        serial_number.rjust(serial_number_length, '0')
+        serial_number && serial_number.rjust(serial_number_length, '0')
       end
 
       def swift_account_number
-        if bank_info.fetch(:include_clearing_code)
+        if bank_info.fetch(:include_clearing_code) &&
+           clearing_code && serial_number
           (clearing_code + serial_number).rjust(17, '0')
         else
-          serial_number.rjust(17, '0')
+          serial_number && serial_number.rjust(17, '0')
         end
       end
     end

--- a/spec/ibandit/sweden/local_details_converter_spec.rb
+++ b/spec/ibandit/sweden/local_details_converter_spec.rb
@@ -131,6 +131,16 @@ describe Ibandit::Sweden::LocalDetailsConverter do
         its([:swift_bank_code]) { is_expected.to eq('800') }
         its([:swift_account_number]) { is_expected.to eq('00820169143579630') }
       end
+
+      context 'in the 8000s range, with a very short input' do
+        let(:account_number) { '8004' }
+        let(:branch_code) { nil }
+
+        its([:account_number]) { is_expected.to be_nil }
+        its([:branch_code]) { is_expected.to eq('8004') }
+        its([:swift_bank_code]) { is_expected.to eq('800') }
+        its([:swift_account_number]) { is_expected.to be_nil }
+      end
     end
 
     context 'with a Sparbanken Öresund clearing code' do


### PR DESCRIPTION
A four-digit account number input, for some banks, would previously
cause a crash as the converter attempted to right-pad a nil. For
instance, any four-digit input between 8000 and 8999 (Swedbank).