### PR TITLE
Missing code released under v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.2 -  July 4, 2016
+
+- Handle invalid pseudo-IBANs
+
 ## 0.11.1 -  June 6, 2016
 
 - Update BLZ data

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,3 +1,3 @@
 module Ibandit
-  VERSION = '0.11.1'.freeze
+  VERSION = '0.11.2'.freeze
 end


### PR DESCRIPTION
This code was released to Rubygems as v0.11.2, but was not committed.

I propose re-tagging v0.11.2 in this repository. It currently points to 744bdba41545b5af3d90154da030e8874d11018e – I would have it point to 6bae55a7f09491d69742f6f404a9cbd79ba0afde (below) to better reflect the code released as v0.11.2.

This pull request can then be merged to `master`, so that the `release-0.11.3` branch in https://github.com/gocardless/ibandit/pull/73 makes more sense.