### PR TITLE
Fix Domincan Republic account number regex

### DIFF
--- a/data/structures.yml
+++ b/data/structures.yml
@@ -210,7 +210,7 @@ DO:
   :national_id_length: 4
   :bban_format: "[A-Z0-9]{4}\\d{20}"
   :bank_code_format: "[A-Z]{4}"
-  :account_number_format: "{4}\\d{20}"
+  :account_number_format: "\\d{20}"
 EE:
   :bank_code_position: 5
   :bank_code_length: 2

--- a/spec/ibandit/structure_spec.rb
+++ b/spec/ibandit/structure_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'structures.yml' do
+  FILE = File.expand_path('../../../data/structures.yml', __FILE__)
+  STRUCTURES = YAML.load_file(FILE)
+
+  STRUCTURES.each do |country, rules|
+    context country do
+      rules.each do |rule, value|
+        next unless rule =~ /_format$/
+
+        it "builds #{rule} rule" do
+          expect { Regexp.new(value) }.to_not raise_exception
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Looks like a bad paste, as `/{4}\d{20}/` is not a valid regular expression.

I think it's supposed to just be 20 chars (cribbed from http://www.xe.com/ibancalculator/sample/?ibancountry=dominican-republic).