### PR TITLE
Support Australian pseudo-IBANs

### DIFF
--- a/data/structures.yml
+++ b/data/structures.yml
@@ -49,6 +49,15 @@ AT:
   :bban_format: "\\d{5}\\d{11}"
   :bank_code_format: "\\d{5}"
   :account_number_format: "\\d{11}"
+AU:
+  :bank_code_length: 0
+  :branch_code_length: 6
+  :account_number_length: 9
+  :branch_code_format: "\\d{6}"
+  :account_number_format: "\\d{9}"
+  :pseudo_iban_bank_code_length: 0
+  :pseudo_iban_branch_code_length: 6
+  :pseudo_iban_account_number_length: 9
 AZ:
   :bank_code_position: 5
   :bank_code_length: 4

--- a/lib/ibandit/constants.rb
+++ b/lib/ibandit/constants.rb
@@ -1,10 +1,14 @@
 module Ibandit
   module Constants
-    SUPPORTED_COUNTRY_CODES = %w[AT BE BG CY CZ DE DK EE ES FI FR GB GR HR HU IE
-                                 IS IT LT LU LV MC MT NL NO PL PT RO SE SI SK
-                                 SM].freeze
+    SUPPORTED_COUNTRY_CODES = %w[AT AU BE BG CY CZ DE DK EE ES FI FR GB GR HR
+                                 HU IE IS IT LT LU LV MC MT NL NO PL PT RO SE
+                                 SI SK SM].freeze
 
-    PSEUDO_IBAN_COUNTRY_CODES = %w[SE].freeze
+    PSEUDO_IBAN_COUNTRY_CODES = %w[AU SE].freeze
+    CONSTRUCTABLE_IBAN_COUNTRY_CODES = SUPPORTED_COUNTRY_CODES - %w[AU]
+    DECONSTRUCTABLE_IBAN_COUNTRY_CODES =
+      SUPPORTED_COUNTRY_CODES - PSEUDO_IBAN_COUNTRY_CODES
+
     PSEUDO_IBAN_CHECK_DIGITS = "ZZ".freeze
   end
 end

--- a/lib/ibandit/pseudo_iban_splitter.rb
+++ b/lib/ibandit/pseudo_iban_splitter.rb
@@ -35,15 +35,16 @@ module Ibandit
     end
 
     def account_number
-      pseudo_iban_part(account_number_start_index,
-                       :pseudo_iban_account_number_length)
+      remove_leading_padding(
+        @pseudo_iban.slice(account_number_start_index, @pseudo_iban.length),
+      )
     end
 
     def pseudo_iban_part(start_index, length_key)
       length = structure.fetch(length_key)
       return if length == 0
 
-      @pseudo_iban.slice(start_index, length).gsub(/\AX+/, "")
+      remove_leading_padding(@pseudo_iban.slice(start_index, length))
     end
 
     def bank_code_start_index
@@ -58,13 +59,8 @@ module Ibandit
       branch_code_start_index + structure.fetch(:pseudo_iban_branch_code_length)
     end
 
-    def expected_length
-      account_number_start_index +
-        structure.fetch(:pseudo_iban_account_number_length)
-    end
-
     def decomposable?
-      country_code_valid? && check_digits_valid? && correct_length?
+      country_code_valid? && check_digits_valid?
     end
 
     def country_code_valid?
@@ -75,12 +71,12 @@ module Ibandit
       check_digits == Constants::PSEUDO_IBAN_CHECK_DIGITS
     end
 
-    def correct_length?
-      @pseudo_iban.length == expected_length
-    end
-
     def structure
       Ibandit.structures[country_code]
+    end
+
+    def remove_leading_padding(input)
+      input.gsub(/\AX+/, "")
     end
   end
 end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -118,6 +118,9 @@ describe Ibandit::IBAN do
       its(:swift_bank_code) { is_expected.to eq(arg[:bank_code]) }
       its(:swift_branch_code) { is_expected.to eq(arg[:branch_code]) }
       its(:swift_account_number) { is_expected.to eq(arg[:account_number]) }
+      its(:pseudo_iban) { is_expected.to be_nil }
+      its(:iban) { is_expected.to eq("GB72WES12345678") }
+      its(:to_s) { is_expected.to eq("GB72WES12345678") }
     end
 
     context "when the IBAN was created with local details for Sweden" do
@@ -138,6 +141,7 @@ describe Ibandit::IBAN do
       its(:swift_account_number) { is_expected.to eq("00000012810105723") }
       its(:iban) { is_expected.to eq("SE5412000000012810105723") }
       its(:pseudo_iban) { is_expected.to eq("SEZZX1281XXX0105723") }
+      its(:to_s) { is_expected.to eq("SE5412000000012810105723") }
     end
 
     context "when the IBAN was created from a pseudo-IBAN" do
@@ -152,6 +156,75 @@ describe Ibandit::IBAN do
       its(:swift_account_number) { is_expected.to eq("00000012810105723") }
       its(:iban) { is_expected.to eq("SE5412000000012810105723") }
       its(:pseudo_iban) { is_expected.to eq("SEZZX1281XXX0105723") }
+      its(:to_s) { is_expected.to eq("SE5412000000012810105723") }
+    end
+
+    context "when the IBAN was created with local details for Australia" do
+      let(:arg) do
+        {
+          country_code: "AU",
+          branch_code: "123-456",
+          account_number: "123456789",
+        }
+      end
+
+      its(:country_code) { is_expected.to eq(arg[:country_code]) }
+      its(:bank_code) { is_expected.to be_nil }
+      its(:branch_code) { is_expected.to eq("123456") }
+      its(:account_number) { is_expected.to eq("123456789") }
+      its(:swift_bank_code) { is_expected.to be_nil }
+      its(:swift_branch_code) { is_expected.to eq("123456") }
+      its(:swift_account_number) { is_expected.to eq("123456789") }
+      its(:iban) { is_expected.to be_nil }
+      its(:pseudo_iban) { is_expected.to eq("AUZZ123456123456789") }
+      its(:valid?) { is_expected.to eq(true) }
+      its(:to_s) { is_expected.to eq("") }
+    end
+
+    context "when the IBAN was created from an Australian pseudo-IBAN" do
+      let(:arg) { "AUZZ123456123456789" }
+
+      its(:country_code) { is_expected.to eq("AU") }
+      its(:bank_code) { is_expected.to be_nil }
+      its(:branch_code) { is_expected.to eq("123456") }
+      its(:account_number) { is_expected.to eq("123456789") }
+      its(:swift_bank_code) { is_expected.to be_nil }
+      its(:swift_branch_code) { is_expected.to eq("123456") }
+      its(:swift_account_number) { is_expected.to eq("123456789") }
+      its(:iban) { is_expected.to be_nil }
+      its(:pseudo_iban) { is_expected.to eq("AUZZ123456123456789") }
+      its(:valid?) { is_expected.to eq(true) }
+      its(:to_s) { is_expected.to eq("") }
+    end
+
+    context "when the input is an invalid Australian pseudo-IBAN" do
+      let(:arg) { "AUZZ1234561234567899999" }
+
+      its(:iban) { is_expected.to be_nil }
+      its(:pseudo_iban) { is_expected.to eq(arg) }
+      it "is invalid and has the correct errors" do
+        expect(subject.valid?).to eq(false)
+        expect(subject.errors).
+          to eq(account_number: "is the wrong length (should be 9 characters)")
+      end
+    end
+
+    context "when the input is invalid local details for Australia" do
+      let(:arg) do
+        {
+          country_code: "AU",
+          branch_code: "123-4XX",
+          account_number: "1234567XX",
+        }
+      end
+
+      its(:iban) { is_expected.to be_nil }
+      its(:pseudo_iban) { is_expected.to eq("AUZZ1234XX1234567XX") }
+      it "is invalid and has the correct errors" do
+        expect(subject.valid?).to eq(false)
+        expect(subject.errors).to eq(account_number: "is invalid",
+                                     branch_code: "is invalid")
+      end
     end
   end
 
@@ -169,6 +242,22 @@ describe Ibandit::IBAN do
       let(:arg) { { country_code: "GB" } }
       its(:to_s) { is_expected.to_not be_nil }
       specify { expect(iban.to_s(:formatted)).to be_empty }
+    end
+
+    context "with Swedish local details" do
+      let(:arg) do
+        {
+          country_code: "SE",
+          branch_code: "1281",
+          account_number: "0105723",
+        }
+      end
+      specify { expect(iban.to_s).to eq("SE5412000000012810105723") }
+    end
+
+    context "with a Swedish pseudo-IBAN" do
+      let(:arg) { "SEZZX1281XXX0105723" }
+      specify { expect(iban.to_s).to eq("SE5412000000012810105723") }
     end
   end
 
@@ -1568,6 +1657,16 @@ describe Ibandit::IBAN do
     context "for a valid Austrian IBAN" do
       let(:iban_code) { "AT61 1904 3002 3457 3201" }
       it { is_expected.to be_valid }
+    end
+
+    context "for a valid Australian pseudo-IBAN" do
+      let(:iban_code) { "AUZZ123456123456789" }
+      it { is_expected.to be_valid }
+    end
+
+    context "for an invalid Australian pseudo-IBAN" do
+      let(:iban_code) { "AU99123456123456789" }
+      it { is_expected.to_not be_valid }
     end
 
     context "for a valid Azerbaijanian IBAN" do

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -76,6 +76,27 @@ describe Ibandit::LocalDetailsCleaner do
     end
   end
 
+  context "Australia" do
+    let(:country_code) { "AU" }
+    let(:account_number) { "123456789" }
+
+    context "with dashes" do
+      let(:branch_code) { "123-456" }
+
+      its([:country_code]) { is_expected.to eq(country_code) }
+      its([:account_number]) { is_expected.to eq(account_number) }
+      its([:branch_code]) { is_expected.to eq("123456") }
+    end
+
+    context "without dashes" do
+      let(:branch_code) { "123456" }
+
+      its([:country_code]) { is_expected.to eq(country_code) }
+      its([:account_number]) { is_expected.to eq(account_number) }
+      its([:branch_code]) { is_expected.to eq("123456") }
+    end
+  end
+
   context "Belgium" do
     let(:country_code) { "BE" }
     let(:account_number) { "510007547061" }
@@ -987,7 +1008,7 @@ describe Ibandit::LocalDetailsCleaner do
 
     context "without an account number" do
       let(:account_number) { nil }
-      it { is_expected.to eq(local_details) }
+      it { is_expected.to eq(local_details_with_swift) }
     end
 
     context "with a bank code" do

--- a/spec/ibandit/pseudo_iban_assembler_spec.rb
+++ b/spec/ibandit/pseudo_iban_assembler_spec.rb
@@ -39,6 +39,42 @@ describe Ibandit::PseudoIBANAssembler do
     end
   end
 
+  context "for Australia" do
+    context "with valid parameters" do
+      let(:local_details) do
+        {
+          country_code: "AU",
+          branch_code: "123456",
+          account_number: "123456789",
+        }
+      end
+
+      it { is_expected.to eq("AUZZ123456123456789") }
+    end
+
+    context "without a branch code" do
+      let(:local_details) do
+        {
+          country_code: "AU",
+          account_number: "123456789",
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "without an account number" do
+      let(:local_details) do
+        {
+          country_code: "AU",
+          branch_code: "123456",
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   context "for a country that does not have pseudo-IBANs" do
     let(:local_details) do
       {

--- a/spec/ibandit/pseudo_iban_splitter_spec.rb
+++ b/spec/ibandit/pseudo_iban_splitter_spec.rb
@@ -6,13 +6,22 @@ describe Ibandit::PseudoIBANSplitter do
   describe "#split" do
     subject(:local_details) { splitter.split }
 
-    context "for a valid pseudo-IBAN" do
+    context "for a swedish pseudo-IBAN" do
       let(:pseudo_iban) { "SEZZX1281XXX0105723" }
 
       its([:country_code]) { is_expected.to eq("SE") }
       its([:bank_code]) { is_expected.to be_nil }
       its([:branch_code]) { is_expected.to eq("1281") }
       its([:account_number]) { is_expected.to eq("0105723") }
+    end
+
+    context "for an australian pseudo-IBAN" do
+      let(:pseudo_iban) { "AUZZ123456123456789" }
+
+      its([:country_code]) { is_expected.to eq("AU") }
+      its([:bank_code]) { is_expected.to be_nil }
+      its([:branch_code]) { is_expected.to eq("123456") }
+      its([:account_number]) { is_expected.to eq("123456789") }
     end
 
     context "for an unsupported country" do


### PR DESCRIPTION
Adds support for Australian pseudo-IBANs

Australian Bank details consist of a BSB number and an account number.

You can create them using: 
```
iban = Ibandit::IBAN.new(
  country_code: 'AU',
  branch_code: '123-456', # 6 digit BSB number
  account_number: '123456789' # 9 digit account number
)
iban.pseudo_iban              # => "AUZZ123456123456789"

iban = Ibandit::IBAN.new('AUZZ123456123456789')
iban.country_code             # => "AU"
iban.branch_code              # => "123456"
iban.account_number           # => "123456789"
```

## TODO:

- [x] How should `iban.valid?` work?
- [x] Update readme with how to use Australian IBANs