### PR TITLE
Return correct swift national id for Australia

### DIFF
--- a/data/structures.yml
+++ b/data/structures.yml
@@ -58,6 +58,7 @@ AU:
   :pseudo_iban_bank_code_length: 0
   :pseudo_iban_branch_code_length: 6
   :pseudo_iban_account_number_length: 9
+  :national_id_length: 6
 AZ:
   :bank_code_position: 5
   :bank_code_length: 4

--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -45,7 +45,7 @@ module Ibandit
     ###################
 
     def swift_national_id
-      return unless decomposable?
+      return if swift_bank_code.nil? && swift_branch_code.nil?
 
       national_id = swift_bank_code.to_s
       national_id += swift_branch_code.to_s

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -175,6 +175,7 @@ describe Ibandit::IBAN do
       its(:swift_bank_code) { is_expected.to be_nil }
       its(:swift_branch_code) { is_expected.to eq("123456") }
       its(:swift_account_number) { is_expected.to eq("123456789") }
+      its(:swift_national_id) { is_expected.to eq("123456") }
       its(:iban) { is_expected.to be_nil }
       its(:pseudo_iban) { is_expected.to eq("AUZZ123456123456789") }
       its(:valid?) { is_expected.to eq(true) }
@@ -191,6 +192,7 @@ describe Ibandit::IBAN do
       its(:swift_bank_code) { is_expected.to be_nil }
       its(:swift_branch_code) { is_expected.to eq("123456") }
       its(:swift_account_number) { is_expected.to eq("123456789") }
+      its(:swift_national_id) { is_expected.to eq("123456") }
       its(:iban) { is_expected.to be_nil }
       its(:pseudo_iban) { is_expected.to eq("AUZZ123456123456789") }
       its(:valid?) { is_expected.to eq(true) }


### PR DESCRIPTION
The swift national id in Australia is the 6 digit BSB number. We don't have a bank code but the BSB is set to the branch code.