### PR TITLE
Fix Australian bank details support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.10 - February 21, 2018
+
+- Fix support for Australian bank accounts
+
 ## 0.11.9 - February 8, 2018
 
 - Add support for Australian swift national ids

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -52,12 +52,12 @@ AT:
 AU:
   :bank_code_length: 0
   :branch_code_length: 6
-  :account_number_length: 9
+  :account_number_length: 10
   :branch_code_format: "\\d{6}"
-  :account_number_format: "\\d{9}"
+  :account_number_format: "[A-Z0-9]{10}"
   :pseudo_iban_bank_code_length: 0
   :pseudo_iban_branch_code_length: 6
-  :pseudo_iban_account_number_length: 9
+  :pseudo_iban_account_number_length: 10
   :national_id_length: 6
 AZ:
   :bank_code_position: 5

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -62,9 +62,15 @@ module Ibandit
     end
 
     def self.clean_au_details(local_details)
+      # Account number may be up to 10 digits long.
+      # Add leading zeros to account number if < 10 digits.
+      #
+      # Minimum account_number length is 6
+      return {} unless local_details[:account_number].length >= 6
+
       {
         branch_code:    local_details[:branch_code].delete("-"),
-        account_number: local_details[:account_number],
+        account_number: local_details[:account_number].rjust(10, "0"),
       }
     end
 

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,3 +1,3 @@
 module Ibandit
-  VERSION = "0.11.9".freeze
+  VERSION = "0.11.10".freeze
 end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -164,22 +164,60 @@ describe Ibandit::IBAN do
         {
           country_code: "AU",
           branch_code: "123-456",
-          account_number: "123456789",
+          account_number: account_number,
         }
       end
 
-      its(:country_code) { is_expected.to eq(arg[:country_code]) }
-      its(:bank_code) { is_expected.to be_nil }
-      its(:branch_code) { is_expected.to eq("123456") }
-      its(:account_number) { is_expected.to eq("123456789") }
-      its(:swift_bank_code) { is_expected.to be_nil }
-      its(:swift_branch_code) { is_expected.to eq("123456") }
-      its(:swift_account_number) { is_expected.to eq("123456789") }
-      its(:swift_national_id) { is_expected.to eq("123456") }
-      its(:iban) { is_expected.to be_nil }
-      its(:pseudo_iban) { is_expected.to eq("AUZZ123456123456789") }
-      its(:valid?) { is_expected.to eq(true) }
-      its(:to_s) { is_expected.to eq("") }
+      context "and a 9 digit account number" do
+        let(:account_number) { "123456789" }
+
+        its(:country_code) { is_expected.to eq("AU") }
+        its(:bank_code) { is_expected.to be_nil }
+        its(:branch_code) { is_expected.to eq("123456") }
+        its(:account_number) { is_expected.to eq("0123456789") }
+        its(:swift_bank_code) { is_expected.to be_nil }
+        its(:swift_branch_code) { is_expected.to eq("123456") }
+        its(:swift_account_number) { is_expected.to eq("0123456789") }
+        its(:swift_national_id) { is_expected.to eq("123456") }
+        its(:iban) { is_expected.to be_nil }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ1234560123456789") }
+        its(:valid?) { is_expected.to eq(true) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+
+      context "and a 6 digit account number" do
+        let(:account_number) { "123456" }
+
+        its(:country_code) { is_expected.to eq("AU") }
+        its(:bank_code) { is_expected.to be_nil }
+        its(:branch_code) { is_expected.to eq("123456") }
+        its(:account_number) { is_expected.to eq("0000123456") }
+        its(:swift_bank_code) { is_expected.to be_nil }
+        its(:swift_branch_code) { is_expected.to eq("123456") }
+        its(:swift_account_number) { is_expected.to eq("0000123456") }
+        its(:swift_national_id) { is_expected.to eq("123456") }
+        its(:iban) { is_expected.to be_nil }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ1234560000123456") }
+        its(:valid?) { is_expected.to eq(true) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+
+      context "and a 10 characters alphanumeric account number" do
+        let(:account_number) { "AB1234567" }
+
+        its(:country_code) { is_expected.to eq("AU") }
+        its(:bank_code) { is_expected.to be_nil }
+        its(:branch_code) { is_expected.to eq("123456") }
+        its(:account_number) { is_expected.to eq("0AB1234567") }
+        its(:swift_bank_code) { is_expected.to be_nil }
+        its(:swift_branch_code) { is_expected.to eq("123456") }
+        its(:swift_account_number) { is_expected.to eq("0AB1234567") }
+        its(:swift_national_id) { is_expected.to eq("123456") }
+        its(:iban) { is_expected.to be_nil }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ1234560AB1234567") }
+        its(:valid?) { is_expected.to eq(true) }
+        its(:to_s) { is_expected.to eq("") }
+      end
     end
 
     context "when the IBAN was created from an Australian pseudo-IBAN" do
@@ -188,13 +226,13 @@ describe Ibandit::IBAN do
       its(:country_code) { is_expected.to eq("AU") }
       its(:bank_code) { is_expected.to be_nil }
       its(:branch_code) { is_expected.to eq("123456") }
-      its(:account_number) { is_expected.to eq("123456789") }
+      its(:account_number) { is_expected.to eq("0123456789") }
       its(:swift_bank_code) { is_expected.to be_nil }
       its(:swift_branch_code) { is_expected.to eq("123456") }
-      its(:swift_account_number) { is_expected.to eq("123456789") }
+      its(:swift_account_number) { is_expected.to eq("0123456789") }
       its(:swift_national_id) { is_expected.to eq("123456") }
       its(:iban) { is_expected.to be_nil }
-      its(:pseudo_iban) { is_expected.to eq("AUZZ123456123456789") }
+      its(:pseudo_iban) { is_expected.to eq("AUZZ1234560123456789") }
       its(:valid?) { is_expected.to eq(true) }
       its(:to_s) { is_expected.to eq("") }
     end
@@ -207,7 +245,7 @@ describe Ibandit::IBAN do
       it "is invalid and has the correct errors" do
         expect(subject.valid?).to eq(false)
         expect(subject.errors).
-          to eq(account_number: "is the wrong length (should be 9 characters)")
+          to eq(account_number: "is the wrong length (should be 10 characters)")
       end
     end
 
@@ -216,12 +254,12 @@ describe Ibandit::IBAN do
         {
           country_code: "AU",
           branch_code: "123-4XX",
-          account_number: "1234567XX",
+          account_number: "123456789:",
         }
       end
 
       its(:iban) { is_expected.to be_nil }
-      its(:pseudo_iban) { is_expected.to eq("AUZZ1234XX1234567XX") }
+      its(:pseudo_iban) { is_expected.to eq("AUZZ1234XX123456789:") }
       it "is invalid and has the correct errors" do
         expect(subject.valid?).to eq(false)
         expect(subject.errors).to eq(account_number: "is invalid",

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -84,7 +84,7 @@ describe Ibandit::LocalDetailsCleaner do
       let(:branch_code) { "123-456" }
 
       its([:country_code]) { is_expected.to eq(country_code) }
-      its([:account_number]) { is_expected.to eq(account_number) }
+      its([:account_number]) { is_expected.to eq("0123456789") }
       its([:branch_code]) { is_expected.to eq("123456") }
     end
 
@@ -92,7 +92,7 @@ describe Ibandit::LocalDetailsCleaner do
       let(:branch_code) { "123456" }
 
       its([:country_code]) { is_expected.to eq(country_code) }
-      its([:account_number]) { is_expected.to eq(account_number) }
+      its([:account_number]) { is_expected.to eq("0123456789") }
       its([:branch_code]) { is_expected.to eq("123456") }
     end
   end

--- a/spec/ibandit/pseudo_iban_assembler_spec.rb
+++ b/spec/ibandit/pseudo_iban_assembler_spec.rb
@@ -45,11 +45,11 @@ describe Ibandit::PseudoIBANAssembler do
         {
           country_code: "AU",
           branch_code: "123456",
-          account_number: "123456789",
+          account_number: "A123456789",
         }
       end
 
-      it { is_expected.to eq("AUZZ123456123456789") }
+      it { is_expected.to eq("AUZZ123456A123456789") }
     end
 
     context "without a branch code" do


### PR DESCRIPTION
**Why?**

The previous implementation required 9-digit bank accounts. However,
Australian bank accounts can be between 6 and 10 characters long and
non-AUD bank accounts can be alphanumeric.

This adds support for such bank accounts.