### PR TITLE
Fix padding for Australian pseudo ibans

### DIFF
--- a/lib/ibandit/constants.rb
+++ b/lib/ibandit/constants.rb
@@ -10,6 +10,11 @@ module Ibandit
 
     PSEUDO_IBAN_CHECK_DIGITS = "ZZ".freeze
 
+    PSEUDO_IBAN_PADDING_CHARACTER_FOR = {
+      "SE" => "X", # Using X for backwards compatibility
+      "AU" => "_", # Using _ because AU account numbers are alphanumeric
+    }.freeze
+
     SUPPORTED_COUNTRY_CODES = (
       CONSTRUCTABLE_IBAN_COUNTRY_CODES +
       DECONSTRUCTABLE_IBAN_COUNTRY_CODES +

--- a/lib/ibandit/pseudo_iban_assembler.rb
+++ b/lib/ibandit/pseudo_iban_assembler.rb
@@ -35,6 +35,10 @@ module Ibandit
       Constants::PSEUDO_IBAN_COUNTRY_CODES.include?(@country_code)
     end
 
+    def padding_character
+      Constants::PSEUDO_IBAN_PADDING_CHARACTER_FOR[@country_code]
+    end
+
     def bank_code_valid?
       param_valid?(@bank_code, :pseudo_iban_bank_code_length)
     end
@@ -67,7 +71,7 @@ module Ibandit
 
     def pad(number, length_key)
       return if number.nil?
-      number.rjust(structure[length_key], "X")
+      number.rjust(structure[length_key], padding_character)
     end
 
     def structure

--- a/lib/ibandit/pseudo_iban_splitter.rb
+++ b/lib/ibandit/pseudo_iban_splitter.rb
@@ -65,12 +65,17 @@ module Ibandit
       Constants::PSEUDO_IBAN_COUNTRY_CODES.include?(country_code)
     end
 
+    def padding_character
+      Constants::PSEUDO_IBAN_PADDING_CHARACTER_FOR[country_code]
+    end
+
     def structure
       Ibandit.structures[country_code]
     end
 
     def remove_leading_padding(input)
-      input.gsub(/\AX+/, "")
+      return unless padding_character
+      input.gsub(/\A#{padding_character}+/, "")
     end
   end
 end

--- a/spec/ibandit/constants_spec.rb
+++ b/spec/ibandit/constants_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe Ibandit::Constants do
+  Ibandit::Constants::PSEUDO_IBAN_COUNTRY_CODES.each do |country_code|
+    context country_code do
+      it "has padding character" do
+        padding =
+          Ibandit::Constants::PSEUDO_IBAN_PADDING_CHARACTER_FOR[country_code]
+        expect(padding).to_not be_nil
+        expect(padding.length).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -202,19 +202,53 @@ describe Ibandit::IBAN do
         its(:to_s) { is_expected.to eq("") }
       end
 
-      context "and a 10 characters alphanumeric account number" do
-        let(:account_number) { "AB1234567" }
+      context "and a 10 characters account number" do
+        let(:account_number) { "ABC1234567" }
 
         its(:country_code) { is_expected.to eq("AU") }
         its(:bank_code) { is_expected.to be_nil }
         its(:branch_code) { is_expected.to eq("123456") }
-        its(:account_number) { is_expected.to eq("0AB1234567") }
+        its(:account_number) { is_expected.to eq("ABC1234567") }
         its(:swift_bank_code) { is_expected.to be_nil }
         its(:swift_branch_code) { is_expected.to eq("123456") }
-        its(:swift_account_number) { is_expected.to eq("0AB1234567") }
+        its(:swift_account_number) { is_expected.to eq("ABC1234567") }
         its(:swift_national_id) { is_expected.to eq("123456") }
         its(:iban) { is_expected.to be_nil }
-        its(:pseudo_iban) { is_expected.to eq("AUZZ1234560AB1234567") }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ123456ABC1234567") }
+        its(:valid?) { is_expected.to eq(true) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+
+      context "and a 9 characters account number starting with X" do
+        let(:account_number) { "XX1234567" }
+
+        its(:country_code) { is_expected.to eq("AU") }
+        its(:bank_code) { is_expected.to be_nil }
+        its(:branch_code) { is_expected.to eq("123456") }
+        its(:account_number) { is_expected.to eq("0XX1234567") }
+        its(:swift_bank_code) { is_expected.to be_nil }
+        its(:swift_branch_code) { is_expected.to eq("123456") }
+        its(:swift_account_number) { is_expected.to eq("0XX1234567") }
+        its(:swift_national_id) { is_expected.to eq("123456") }
+        its(:iban) { is_expected.to be_nil }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ1234560XX1234567") }
+        its(:valid?) { is_expected.to eq(true) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+
+      context "and a 10 characters account number starting with X" do
+        let(:account_number) { "XX12345678" }
+
+        its(:country_code) { is_expected.to eq("AU") }
+        its(:bank_code) { is_expected.to be_nil }
+        its(:branch_code) { is_expected.to eq("123456") }
+        its(:account_number) { is_expected.to eq("XX12345678") }
+        its(:swift_bank_code) { is_expected.to be_nil }
+        its(:swift_branch_code) { is_expected.to eq("123456") }
+        its(:swift_account_number) { is_expected.to eq("XX12345678") }
+        its(:swift_national_id) { is_expected.to eq("123456") }
+        its(:iban) { is_expected.to be_nil }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ123456XX12345678") }
         its(:valid?) { is_expected.to eq(true) }
         its(:to_s) { is_expected.to eq("") }
       end
@@ -235,6 +269,23 @@ describe Ibandit::IBAN do
       its(:pseudo_iban) { is_expected.to eq("AUZZ1234560123456789") }
       its(:valid?) { is_expected.to eq(true) }
       its(:to_s) { is_expected.to eq("") }
+
+      context "with a leading X on the account number" do
+        let(:arg) { "AUZZ123456XABCD12345" }
+
+        its(:country_code) { is_expected.to eq("AU") }
+        its(:bank_code) { is_expected.to be_nil }
+        its(:branch_code) { is_expected.to eq("123456") }
+        its(:account_number) { is_expected.to eq("XABCD12345") }
+        its(:swift_bank_code) { is_expected.to be_nil }
+        its(:swift_branch_code) { is_expected.to eq("123456") }
+        its(:swift_account_number) { is_expected.to eq("XABCD12345") }
+        its(:swift_national_id) { is_expected.to eq("123456") }
+        its(:iban) { is_expected.to be_nil }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ123456XABCD12345") }
+        its(:valid?) { is_expected.to eq(true) }
+        its(:to_s) { is_expected.to eq("") }
+      end
     end
 
     context "when the input is an invalid Australian pseudo-IBAN" do

--- a/spec/ibandit/pseudo_iban_assembler_spec.rb
+++ b/spec/ibandit/pseudo_iban_assembler_spec.rb
@@ -52,6 +52,18 @@ describe Ibandit::PseudoIBANAssembler do
       it { is_expected.to eq("AUZZ123456A123456789") }
     end
 
+    context "with valid parameters and padding" do
+      let(:local_details) do
+        {
+          country_code: "AU",
+          branch_code: "123456",
+          account_number: "XABC",
+        }
+      end
+
+      it { is_expected.to eq("AUZZ123456______XABC") }
+    end
+
     context "without a branch code" do
       let(:local_details) do
         {

--- a/spec/ibandit/pseudo_iban_splitter_spec.rb
+++ b/spec/ibandit/pseudo_iban_splitter_spec.rb
@@ -23,5 +23,41 @@ describe Ibandit::PseudoIBANSplitter do
       its([:branch_code]) { is_expected.to eq("123456") }
       its([:account_number]) { is_expected.to eq("123456789") }
     end
+
+    context "for an australian pseudo-IBAN with padding" do
+      let(:pseudo_iban) { "AUZZ123456______XABC" }
+
+      its([:country_code]) { is_expected.to eq("AU") }
+      its([:bank_code]) { is_expected.to be_nil }
+      its([:branch_code]) { is_expected.to eq("123456") }
+      its([:account_number]) { is_expected.to eq("XABC") }
+    end
+
+    context "for an australian 10 character alphanumeric pseudo-iban" do
+      let(:pseudo_iban) { "AUZZ12345601234567AB" }
+
+      its([:country_code]) { is_expected.to eq("AU") }
+      its([:bank_code]) { is_expected.to be_nil }
+      its([:branch_code]) { is_expected.to eq("123456") }
+      its([:account_number]) { is_expected.to eq("01234567AB") }
+    end
+
+    context "for an australian 10 character pseudo-iban with an X" do
+      let(:pseudo_iban) { "AUZZ1234560X12345678" }
+
+      its([:country_code]) { is_expected.to eq("AU") }
+      its([:bank_code]) { is_expected.to be_nil }
+      its([:branch_code]) { is_expected.to eq("123456") }
+      its([:account_number]) { is_expected.to eq("0X12345678") }
+    end
+
+    context "for an australian 10 character pseudo-iban with a leading X" do
+      let(:pseudo_iban) { "AUZZ123456X123456789" }
+
+      its([:country_code]) { is_expected.to eq("AU") }
+      its([:bank_code]) { is_expected.to be_nil }
+      its([:branch_code]) { is_expected.to eq("123456") }
+      its([:account_number]) { is_expected.to eq("X123456789") }
+    end
   end
 end


### PR DESCRIPTION
When we calculate pseudo-ibans, if the account number is shorter than the
expected lenght, the pseudo-iban is right-justified with `X`. The leading
`X`s are then stripped on the splitter.

That worked well for Sweedish accounts, since the account number is only
digits.

However, in Australia, account numbers are alphanumeric, which means an
account number can start with `X`.

We had to use a different padding for Australia but keep using `X` for
backwards compatibility of Sweedish pseudo ibans.