### PR TITLE
Validate BSB for Australian PseudoIBANs

### DIFF
--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -269,6 +269,7 @@ module Ibandit
       case country_code
       when "DE" then supports_iban_determination?
       when "SE" then valid_swedish_details?
+      when "AU" then valid_australian_details?
       else true
       end
     end
@@ -339,6 +340,19 @@ module Ibandit
       end
 
       true
+    end
+
+    def valid_australian_details?
+      return true unless country_code == "AU"
+
+      bsb_check?
+    end
+
+    def bsb_check?
+      return true unless country_code == "AU"
+      return true unless Ibandit.modulus_checker
+
+      valid_modulus_check_branch_code?
     end
 
     ###################


### PR DESCRIPTION
BSB Directories such as those provided by the Australian Payments Network (and downloadable from [here](http://bsb.apca.com.au/public/BSB_DB.NSF/publicBSB.xsp)) can be used to perform a BSB lookup in order to validate the existence of a specified BSB.  Consequently, this BSB check can potentially be carried out as part of the `branch_code_check` in Ibandit's configured modulus checker. 

As modulus checks are only carried out on IBANs, this PR extends the country-specific validation checks for Australian pseudoIBANs to cover the validation of BSB codes using the configured modulus checker.