### PR TITLE
loosen i18n version

### DIFF
--- a/ibandit.gemspec
+++ b/ibandit.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop",         "~> 0.52.0"
   gem.add_development_dependency "sax-machine",     "~> 1.3"
 
-  gem.add_runtime_dependency "i18n", "~> 0.7.0"
+  gem.add_runtime_dependency "i18n"
 
   gem.authors = %w[GoCardless]
   gem.description = "Ibandit is a Ruby library for manipulating and " \


### PR DESCRIPTION
makes it possible to use newer ibandit versions on projects with newer i18n.

for example, i have a project with i18n 0.9.1 in the `Gemfile.lock`. i tried to upgrade ibandit to the most current version but the '~> 0.7.0' requirement kept the ibandit verison at 0.3.4.

loosening the version allows for more flexible and up-to-date code bases.