### PR TITLE
Add pseudoIBAN support for NZ bank account numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ For example:
 | Malta           | :white_check_mark:           | :white_check_mark: |                    |
 | Netherlands     | :white_check_mark:           | :white_check_mark: |                    |
 | Norway          | :white_check_mark:           | :white_check_mark: |                    |
+| New Zealand     |                              |                    | :white_check_mark: |
 | Poland          | :white_check_mark:           | :white_check_mark: |                    |
 | Portugal        | :white_check_mark:           | :white_check_mark: |                    |
 | Romania         | :white_check_mark:           | :white_check_mark: |                    |
@@ -516,6 +517,31 @@ iban.country_code             # => "AU"
 iban.branch_code              # => "123456"
 iban.account_number           # => "123456789"
 iban.iban                     # => nil
+
+# New Zealand
+iban = Ibandit::IBAN.new(
+  country_code: 'NZ',
+  bank_code: '01',
+  branch_code: '5659',
+  account_number: '3333333-44' # 7 digit account number and 2/3-digit account suffix
+)
+iban.pseudo_iban            # => "NZZZ0156593333333044"
+iban.iban                   # => nil
+
+iban = Ibandit::IBAN.new(
+  country_code: 'NZ',
+  account_number: '01-5659-3333333-44'
+)
+iban.pseudo_iban          # => "NZZZ0156593333333044"
+iban.bank_code            # => "01"
+iban.branch_code          # => "5659"
+iban.account_number       # => "3333333044"
+
+iban = Ibandit::IBAN.new('NZZZ0156593333333044')
+iban.country_code         # => "NZ"
+iban.bank_code            # => "01"
+iban.branch_code          # => "5659"
+iban.account_number       # => "3333333044"
 ```
 
 ## Other libraries

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -647,6 +647,17 @@ NL:
   :account_number_format: "\\d{6}\\d{1}"
   :local_check_digit_position: 15
   :local_check_digit_length: 1
+NZ:
+  :bank_code_length: 2
+  :branch_code_length: 4
+  :account_number_length: 10
+  :bank_code_format: "\\d{2}"
+  :branch_code_format: "\\d{4}"
+  :account_number_format: "\\d{7}\\d{3}"
+  :pseudo_iban_bank_code_length: 2
+  :pseudo_iban_branch_code_length: 4
+  :pseudo_iban_account_number_length: 10
+  :national_id_length: 6
 PK:
   :bank_code_position: 5
   :bank_code_length: 4

--- a/lib/ibandit/constants.rb
+++ b/lib/ibandit/constants.rb
@@ -4,7 +4,7 @@ module Ibandit
                                           HR HU IE IS IT LT LU LV MC MT NL NO PL
                                           PT RO SE SI SK SM].freeze
 
-    PSEUDO_IBAN_COUNTRY_CODES = %w[AU SE].freeze
+    PSEUDO_IBAN_COUNTRY_CODES = %w[AU SE NZ].freeze
     DECONSTRUCTABLE_IBAN_COUNTRY_CODES =
       CONSTRUCTABLE_IBAN_COUNTRY_CODES - PSEUDO_IBAN_COUNTRY_CODES
 
@@ -13,6 +13,7 @@ module Ibandit
     PSEUDO_IBAN_PADDING_CHARACTER_FOR = {
       "SE" => "X", # Using X for backwards compatibility
       "AU" => "_", # Using _ because AU account numbers are alphanumeric
+      "NZ" => "_",
     }.freeze
 
     SUPPORTED_COUNTRY_CODES = (

--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -3,8 +3,8 @@ require "yaml"
 module Ibandit
   class IBAN
     attr_reader :errors, :iban, :country_code, :check_digits, :bank_code,
-                :branch_code, :account_number, :swift_bank_code,
-                :swift_branch_code, :swift_account_number, :source
+                :branch_code, :swift_bank_code, :swift_branch_code,
+                :swift_account_number, :source
 
     def initialize(argument)
       if argument.is_a?(String)
@@ -52,6 +52,18 @@ module Ibandit
       national_id.slice(0, structure[:national_id_length])
     end
 
+    def account_number
+      return @account_number unless country_code == "NZ"
+
+      @account_number[0..6]
+    end
+
+    def account_number_suffix
+      return nil unless country_code == "NZ"
+
+      @account_number[7..-1]
+    end
+
     def local_check_digits
       return unless decomposable? && structure[:local_check_digit_position]
 
@@ -70,7 +82,7 @@ module Ibandit
         country_code: country_code,
         bank_code: bank_code,
         branch_code: branch_code,
-        account_number: account_number,
+        account_number: @account_number,
       ).assemble
     end
 

--- a/lib/ibandit/pseudo_iban_splitter.rb
+++ b/lib/ibandit/pseudo_iban_splitter.rb
@@ -31,8 +31,7 @@ module Ibandit
 
     def branch_code
       return unless country_code_valid?
-      pseudo_iban_part(branch_code_start_index,
-                       :pseudo_iban_branch_code_length)
+      pseudo_iban_part(branch_code_start_index, :pseudo_iban_branch_code_length)
     end
 
     def account_number

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -54,6 +54,7 @@ describe Ibandit::IBAN do
     its(:bank_code) { is_expected.to eq("WEST") }
     its(:branch_code) { is_expected.to eq("123456") }
     its(:account_number) { is_expected.to eq("98765432") }
+    its(:account_number_suffix) { is_expected.to eq(nil) }
     its(:swift_bank_code) { is_expected.to eq("WEST") }
     its(:swift_branch_code) { is_expected.to eq("123456") }
     its(:swift_account_number) { is_expected.to eq("98765432") }
@@ -68,6 +69,7 @@ describe Ibandit::IBAN do
       its(:bank_code) { is_expected.to be_nil }
       its(:branch_code) { is_expected.to be_nil }
       its(:account_number) { is_expected.to be_nil }
+      its(:account_number_suffix) { is_expected.to be_nil }
       its(:swift_national_id) { is_expected.to be_nil }
       its(:bban) { is_expected.to be_nil }
       its(:local_check_digits) { is_expected.to be_nil }
@@ -81,6 +83,7 @@ describe Ibandit::IBAN do
       its(:bank_code) { is_expected.to be_nil }
       its(:branch_code) { is_expected.to be_nil }
       its(:account_number) { is_expected.to be_nil }
+      its(:account_number_suffix) { is_expected.to be_nil }
       its(:swift_bank_code) { is_expected.to eq("800") }
       its(:swift_branch_code) { is_expected.to be_nil }
       its(:swift_account_number) { is_expected.to eq("00000075071211203") }
@@ -94,6 +97,7 @@ describe Ibandit::IBAN do
       its(:bank_code) { is_expected.to eq("19100") }
       its(:branch_code) { is_expected.to be_nil }
       its(:account_number) { is_expected.to eq("0000123438") }
+      its(:account_number_suffix) { is_expected.to be_nil }
       its(:swift_bank_code) { is_expected.to eq("19100") }
       its(:swift_branch_code) { is_expected.to be_nil }
       its(:swift_account_number) { is_expected.to eq("0000123438") }
@@ -351,6 +355,119 @@ describe Ibandit::IBAN do
         expect(subject.valid?).to eq(false)
         expect(subject.errors).to eq(account_number: "is invalid",
                                      branch_code: "is invalid")
+      end
+    end
+
+    context "when the IBAN was created with local details for New Zealand" do
+      let(:arg) do
+        {
+          country_code: "NZ",
+          bank_code: "11",
+          branch_code: "2222",
+          account_number: account_number,
+        }
+      end
+      context "with a 3 digit account number suffix" do
+        let(:account_number) { "3333333-944" }
+
+        its(:country_code) { is_expected.to eq("NZ") }
+        its(:bank_code) { is_expected.to eq("11") }
+        its(:branch_code) { is_expected.to eq("2222") }
+        its(:account_number) { is_expected.to eq("3333333") }
+        its(:account_number_suffix) { is_expected.to eq("944") }
+        its(:swift_bank_code) { is_expected.to eq("11") }
+        its(:swift_branch_code) { is_expected.to eq("2222") }
+        its(:swift_account_number) { is_expected.to eq("3333333944") }
+        its(:swift_national_id) { is_expected.to eq("112222") }
+        its(:iban) { is_expected.to be_nil }
+        its(:pseudo_iban) { is_expected.to eq("NZZZ1122223333333944") }
+        its(:valid?) { is_expected.to eq(true) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+      context "with a 2 digit account number suffix" do
+        let(:account_number) { "3333333-44" }
+
+        its(:country_code) { is_expected.to eq("NZ") }
+        its(:bank_code) { is_expected.to eq("11") }
+        its(:branch_code) { is_expected.to eq("2222") }
+        its(:account_number) { is_expected.to eq("3333333") }
+        its(:account_number_suffix) { is_expected.to eq("044") }
+        its(:swift_bank_code) { is_expected.to eq("11") }
+        its(:swift_branch_code) { is_expected.to eq("2222") }
+        its(:swift_account_number) { is_expected.to eq("3333333044") }
+        its(:swift_national_id) { is_expected.to eq("112222") }
+        its(:iban) { is_expected.to be_nil }
+        its(:pseudo_iban) { is_expected.to eq("NZZZ1122223333333044") }
+        its(:valid?) { is_expected.to eq(true) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+      context "with bank and branch code embedded in account_number field" do
+        let(:arg) do
+          {
+            country_code: "NZ",
+            account_number: "11-2222-3333333-44",
+          }
+        end
+
+        its(:country_code) { is_expected.to eq("NZ") }
+        its(:bank_code) { is_expected.to eq("11") }
+        its(:branch_code) { is_expected.to eq("2222") }
+        its(:account_number) { is_expected.to eq("3333333") }
+        its(:account_number_suffix) { is_expected.to eq("044") }
+        its(:swift_bank_code) { is_expected.to eq("11") }
+        its(:swift_branch_code) { is_expected.to eq("2222") }
+        its(:swift_account_number) { is_expected.to eq("3333333044") }
+        its(:swift_national_id) { is_expected.to eq("112222") }
+        its(:iban) { is_expected.to be_nil }
+        its(:pseudo_iban) { is_expected.to eq("NZZZ1122223333333044") }
+        its(:valid?) { is_expected.to eq(true) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+      context "with a bank code embedded in account_number field" do
+        let(:arg) do
+          {
+            country_code: "NZ",
+            account_number: "11-3333333-44",
+            branch_code: "2222",
+          }
+        end
+
+        it "is invalid and has the correct errors" do
+          expect(subject.valid?).to eq(false)
+          expect(subject.errors).to eq(
+            account_number: "is the wrong length (should be 10 characters)",
+          )
+        end
+      end
+    end
+
+    context "when the IBAN was created from a New Zealand pseudo-IBAN" do
+      let(:arg) { "NZZZ1122223333333044" }
+
+      its(:country_code) { is_expected.to eq("NZ") }
+      its(:bank_code) { is_expected.to eq("11") }
+      its(:branch_code) { is_expected.to eq("2222") }
+      its(:account_number) { is_expected.to eq("3333333") }
+      its(:account_number_suffix) { is_expected.to eq("044") }
+      its(:swift_bank_code) { is_expected.to eq("11") }
+      its(:swift_branch_code) { is_expected.to eq("2222") }
+      its(:swift_account_number) { is_expected.to eq("3333333044") }
+      its(:swift_national_id) { is_expected.to eq("112222") }
+      its(:iban) { is_expected.to be_nil }
+      its(:pseudo_iban) { is_expected.to eq("NZZZ1122223333333044") }
+      its(:valid?) { is_expected.to eq(true) }
+      its(:to_s) { is_expected.to eq("") }
+    end
+
+    context "when the input is an invalid New Zealand pseudo-IBAN" do
+      let(:arg) { "NZZZ11222233333330444" }
+
+      its(:iban) { is_expected.to be_nil }
+      its(:pseudo_iban) { is_expected.to eq(arg) }
+      it "is invalid and has the correct errors" do
+        expect(subject.valid?).to eq(false)
+        expect(subject.errors).
+          to eq(account_number: "is the wrong length (should be 10 characters)")
       end
     end
   end
@@ -2274,6 +2391,16 @@ describe Ibandit::IBAN do
 
     context "for an invalid Norwegian IBAN" do
       let(:iban_code) { "NO23 8601 1117 947" }
+      it { is_expected.to_not be_valid }
+    end
+
+    context "for a valid New Zealand pseudo-IBAN" do
+      let(:iban_code) { "NZZZ5566667777777088" }
+      it { is_expected.to be_valid }
+    end
+
+    context "for an invalid New Zealand pseudo-IBAN" do
+      let(:iban_code) { "NZZZ55666677777770888" }
       it { is_expected.to_not be_valid }
     end
 

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -932,6 +932,38 @@ describe Ibandit::LocalDetailsCleaner do
     end
   end
 
+  context "New Zealand" do
+    let(:country_code) { "NZ" }
+    let(:bank_code) { "11" }
+    let(:branch_code) { "2222" }
+    let(:account_number) { "3333333044" }
+
+    it { is_expected.to eq(local_details_with_swift) }
+
+    context "with bank and branch codes in the account number" do
+      let(:bank_code) { nil }
+      let(:branch_code) { nil }
+      let(:account_number) { "11-2222-3333333-044" }
+
+      its([:bank_code]) { is_expected.to eq("11") }
+      its([:branch_code]) { is_expected.to eq("2222") }
+      its([:account_number]) { is_expected.to eq("3333333044") }
+
+      context "with a 2-digit account number suffix" do
+        let(:account_number) { "11-2222-3333333-44" }
+
+        its([:bank_code]) { is_expected.to eq("11") }
+        its([:branch_code]) { is_expected.to eq("2222") }
+        its([:account_number]) { is_expected.to eq("3333333044") }
+      end
+    end
+
+    context "without an account number" do
+      let(:account_number) { nil }
+      it { is_expected.to eq(local_details_with_swift) }
+    end
+  end
+
   context "Poland" do
     let(:country_code) { "PL" }
     let(:bank_code) { "10201026" }

--- a/spec/ibandit/pseudo_iban_assembler_spec.rb
+++ b/spec/ibandit/pseudo_iban_assembler_spec.rb
@@ -87,6 +87,57 @@ describe Ibandit::PseudoIBANAssembler do
     end
   end
 
+  context "for New Zealand" do
+    context "with valid parameters" do
+      let(:local_details) do
+        {
+          country_code: "NZ",
+          bank_code: "11",
+          branch_code: "2222",
+          account_number: "3333333044",
+        }
+      end
+
+      it { is_expected.to eq("NZZZ1122223333333044") }
+    end
+
+    context "without a bank_code" do
+      let(:local_details) do
+        {
+          country_code: "NZ",
+          branch_code: "5569",
+          account_number: "1234567",
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "without a branch code" do
+      let(:local_details) do
+        {
+          country_code: "NZ",
+          bank_code: "01",
+          account_number: "1234567",
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "without an account number" do
+      let(:local_details) do
+        {
+          country_code: "NZ",
+          bank_code: "01",
+          branch_code: "5569",
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   context "for a country that does not have pseudo-IBANs" do
     let(:local_details) do
       {

--- a/spec/ibandit/pseudo_iban_splitter_spec.rb
+++ b/spec/ibandit/pseudo_iban_splitter_spec.rb
@@ -15,6 +15,15 @@ describe Ibandit::PseudoIBANSplitter do
       its([:account_number]) { is_expected.to eq("0105723") }
     end
 
+    context "for a New Zealand pseudo-IBAN" do
+      let(:pseudo_iban) { "NZZZ0156997777777030" }
+
+      its([:country_code]) { is_expected.to eq("NZ") }
+      its([:bank_code]) { is_expected.to eq("01") }
+      its([:branch_code]) { is_expected.to eq("5699") }
+      its([:account_number]) { is_expected.to eq("7777777030") }
+    end
+
     context "for an australian pseudo-IBAN" do
       let(:pseudo_iban) { "AUZZ123456123456789" }
 


### PR DESCRIPTION
This PR adds support for account numbers from New Zealand banks. We use pseudo-IBANs because New Zealand doesn't use IBANs. Instead, they follow a standardised format of 16 digits which is generally presented as `BB-bbbb-AAAAAAA-0SS` where: 

- B is the bank number (2 digits)
- b is the branch number (4 digits)
- A is the account number (7 digits) and
- S are digits of the suffix (2 or 3 digits)

> Technically, all NZD banks have three digit suffixes, it's just that the first digit of the suffix is always 0 so it's usually ignored. 

Account Number Suffix section in https://en.wikipedia.org/wiki/New_Zealand_bank_account_number

Like for other existing countries with pseudoIBANs(Swedend and Australia), Ibandit::IBAN objects for NZD can be initialized from either a pseudoIBAN string or local details. 

When initializing with local details, these can be supplied in two ways:

- As their individual component parts (with the account number field containing both the 7-digit account_number body and 2/3-digit account suffix) like in:

```ruby
iban = Ibandit::IBAN.new(
  country_code: 'NZ',
  bank_code: '01',
  branch_code: '5659',
  account_number: '3333333-44' # 7 digit account number and 2/3-digit account suffix
)
```

- As a single 15/16-digit account_number string from which all of the individual components are extracted e.g

```ruby
iban = Ibandit::IBAN.new(
  country_code: 'NZ',
  account_number: '01-5659-3333333-44'
)
```