### PR TITLE
Validate branch codes for NewZealand PseudoIBANs

### DIFF
--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -282,6 +282,7 @@ module Ibandit
       when "DE" then supports_iban_determination?
       when "SE" then valid_swedish_details?
       when "AU" then valid_australian_details?
+      when "NZ" then valid_nz_details?
       else true
       end
     end
@@ -352,6 +353,13 @@ module Ibandit
       end
 
       true
+    end
+
+    def valid_nz_details?
+      return true unless country_code == "NZ"
+      return true unless Ibandit.modulus_checker
+
+      valid_modulus_check_branch_code?
     end
 
     def valid_australian_details?

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -1952,6 +1952,108 @@ describe Ibandit::IBAN do
     end
   end
 
+  describe "valid_nz_details" do
+    subject { iban.valid_nz_details? }
+
+    context "with non-NewZealand details" do
+      let(:arg) do
+        {
+          country_code: "GB",
+          bank_code: "1234",
+          branch_code: "200000",
+          account_number: "55779911",
+        }
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with NewZealand details" do
+      let(:arg) do
+        {
+          country_code: "NZ",
+          bank_code: "01",
+          branch_code: "0004",
+          account_number: "123456789",
+        }
+      end
+
+      context "without a modulus checker defined" do
+        it { is_expected.to be(true) }
+      end
+
+      context "with a modulus checker defined" do
+        before do
+          Ibandit.modulus_checker = double(
+            valid_branch_code?: valid_branch_code,
+          )
+          iban.valid_nz_details?
+        end
+        after { Ibandit.modulus_checker = nil }
+
+        let(:valid_branch_code) { true }
+
+        it "calls valid_branch_code? with an IBAN object" do
+          expect(Ibandit.modulus_checker).
+            to receive(:valid_branch_code?).
+            with(instance_of(Ibandit::IBAN))
+
+          iban.valid_nz_details?
+        end
+
+        it { is_expected.to be(true) }
+
+        context "with an invalid branch code" do
+          let(:valid_branch_code) { false }
+
+          it { is_expected.to be(false) }
+
+          context "locale en", locale: :en do
+            specify do
+              expect(iban.errors).to include(branch_code: "is invalid")
+            end
+          end
+
+          context "locale fr", locale: :fr do
+            specify do
+              expect(iban.errors).to include(branch_code: "est invalide")
+            end
+          end
+
+          context "locale de", locale: :de do
+            specify do
+              expect(iban.errors).to include(branch_code: "ist nicht gültig")
+            end
+          end
+
+          context "locale pt", locale: :pt do
+            specify do
+              expect(iban.errors).to include(branch_code: "é inválido")
+            end
+          end
+
+          context "locale es", locale: :es do
+            specify do
+              expect(iban.errors).to include(branch_code: "es inválido")
+            end
+          end
+
+          context "locale it", locale: :it do
+            specify do
+              expect(iban.errors).to include(branch_code: "non è valido")
+            end
+          end
+
+          context "locale nl", locale: :nl do
+            specify do
+              expect(iban.errors).to include(branch_code: "is ongeldig")
+            end
+          end
+        end
+      end
+    end
+  end
+
   describe "#valid?" do
     describe "validations called" do
       after { iban.valid? }


### PR DESCRIPTION
The [Bank Branch Register](https://www.paymentsnz.co.nz/resources/industry-registers/bank-branch-register/) provided by `paymentsnz` can be used to validate the existence of a specified bank branch in New Zealand. This check can be carried out as part of the `branch_code_check` in Ibandit's configured modulus checker.

As modulus checks are only carried out on IBANs, this commit extends the country-specific validation checks for NewZealand pseudoIBANs to cover the validation of branch codes (if a configured modulus checker exists).