### PR TITLE
Fix short account number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.17 - September 17, 2018
+
+- Do not crash when given too short account numbers for New Zealand
+
 ## 0.11.16 - September 3, 2018
 
 - Loosen `i18n` dependency (thanks @glaszig!)

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -455,7 +455,7 @@ module Ibandit
         account_number = cleaned_account_number[6..-1]
       end
 
-      if account_number.length == 9
+      if account_number && account_number.length == 9
         # > Some banks (such as BNZ) include three digits of the suffix in their
         # > presentation of the account number to the end customer. Other banks
         # > only show the last two digits of the suffix to the end customer.

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,3 +1,3 @@
 module Ibandit
-  VERSION = "0.11.16".freeze
+  VERSION = "0.11.17".freeze
 end

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -956,6 +956,11 @@ describe Ibandit::LocalDetailsCleaner do
         its([:branch_code]) { is_expected.to eq("2222") }
         its([:account_number]) { is_expected.to eq("3333333044") }
       end
+
+      context "when the account number is shorter than 6 chars" do
+        let(:account_number) { "12345" }
+        its([:account_number]) { is_expected.to be_nil }
+      end
     end
 
     context "without an account number" do


### PR DESCRIPTION
If a bank and a branch code is not given, we allow users to specify all
the details through the account number. However if that's shorter than 6
chars it currently crashes whereas we should instead just not validate
the details.

Before the change:
```
[1] pry(main)> iban = Ibandit::IBAN.new(country_code: "NZ", bank_code: nil, branch_code: nil, account_number: "1-1")
NoMethodError: undefined method `length' for nil:NilClass
from /Users/gocardless/gocardless/ibandit/lib/ibandit/local_details_cleaner.rb:458:in `clean_nz_details'
```

After the change:
```
[3] pry(main)> iban = Ibandit::IBAN.new(country_code: "NZ", bank_code: nil, branch_code: nil, account_number: "1-1")
=> #<Ibandit::IBAN:0x00007f8a572b1770
 @account_number=nil,
 @bank_code="11",
 @branch_code="",
 @country_code="NZ",
 @errors={},
 @iban=nil,
 @source=:local_details,
 @swift_account_number=nil,
 @swift_bank_code="11",
 @swift_branch_code="">
[4] pry(main)> iban.valid?
=> false
[5] pry(main)> iban.errors
=> {:branch_code=>"is required", :account_number=>"is required"}
```
