### PR TITLE
Implement pseudo-IBAN split/assemble support for Canada

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For example:
 | Belgium         | :white_check_mark:           | :white_check_mark: |                    |
 | Bulgaria        | :white_check_mark:           | :white_check_mark: |                    |
 | Croatia         | :white_check_mark:           | :white_check_mark: |                    |
+| Canada          |                              |                    | :white_check_mark: |
 | Cyprus          | :white_check_mark:           | :white_check_mark: |                    |
 | Czech Republic  | :white_check_mark:           | :white_check_mark: |                    |
 | Denmark         | :white_check_mark:           | :white_check_mark: |                    |

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -886,3 +886,13 @@ TL:
   :bban_format: "\\d{3}\\d{14}\\d{2}"
   :bank_code_format: "\\d{3}"
   :account_number_format: " \\d{14} \\d{2}"
+CA:
+  :bank_code_length: 4
+  :branch_code_length: 5
+  :account_number_length: 12
+  :bank_code_format: "\\d{4}"
+  :branch_code_format: "\\d{5}"
+  :account_number_format: "\\d{7,12}"
+  :pseudo_iban_bank_code_length: 4
+  :pseudo_iban_branch_code_length: 5
+  :pseudo_iban_account_number_length: 12

--- a/lib/ibandit/constants.rb
+++ b/lib/ibandit/constants.rb
@@ -4,7 +4,7 @@ module Ibandit
                                           HR HU IE IS IT LT LU LV MC MT NL NO PL
                                           PT RO SE SI SK SM].freeze
 
-    PSEUDO_IBAN_COUNTRY_CODES = %w[AU SE NZ].freeze
+    PSEUDO_IBAN_COUNTRY_CODES = %w[AU SE NZ CA].freeze
     DECONSTRUCTABLE_IBAN_COUNTRY_CODES =
       CONSTRUCTABLE_IBAN_COUNTRY_CODES - PSEUDO_IBAN_COUNTRY_CODES
 
@@ -14,6 +14,7 @@ module Ibandit
       "SE" => "X", # Using X for backwards compatibility
       "AU" => "_", # Using _ because AU account numbers are alphanumeric
       "NZ" => "_",
+      "CA" => "_",
     }.freeze
 
     SUPPORTED_COUNTRY_CODES = (

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -84,6 +84,10 @@ module Ibandit
       }
     end
 
+    def self.clean_ca_details(local_details)
+      local_details
+    end
+
     def self.clean_bg_details(local_details)
       # Bulgarian national bank details were replaced with IBANs in 2006.
       local_details

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -358,6 +358,96 @@ describe Ibandit::IBAN do
       end
     end
 
+    context "when the IBAN was created with local details for Canada" do
+      let(:arg) do
+        {
+          country_code: "CA",
+          bank_code: "0036",
+          branch_code: "00063",
+          account_number: account_number,
+        }
+      end
+
+      context "and a 7 digit account number" do
+        let(:account_number) { "0123456" }
+
+        its(:country_code) { is_expected.to eq("CA") }
+        its(:bank_code) { is_expected.to eq("0036") }
+        its(:branch_code) { is_expected.to eq("00063") }
+        its(:account_number) { is_expected.to eq("0123456") }
+        its(:swift_bank_code) { is_expected.to eq("0036") }
+        its(:swift_branch_code) { is_expected.to eq("00063") }
+        its(:swift_account_number) { is_expected.to eq("0123456") }
+        its(:pseudo_iban) { is_expected.to eq("CAZZ003600063_____0123456") }
+
+        # ibandit account number length validation can check for maximum
+        # length but not against a range, say, 7 to 12 digits, allowed in CA.
+        #
+        # given we are only going to deal with pseudo-IBANs in CA, choosing to
+        # not complete IBAN validation unless we need it.
+        #
+        its(:iban) { is_expected.to be_nil }
+        its(:valid?) { is_expected.to eq(false) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+
+      context "and a 12 digit account number" do
+        let(:account_number) { "012345678900" }
+
+        its(:country_code) { is_expected.to eq("CA") }
+        its(:bank_code) { is_expected.to eq("0036") }
+        its(:branch_code) { is_expected.to eq("00063") }
+        its(:account_number) { is_expected.to eq("012345678900") }
+        its(:swift_bank_code) { is_expected.to eq("0036") }
+        its(:swift_branch_code) { is_expected.to eq("00063") }
+        its(:swift_account_number) { is_expected.to eq("012345678900") }
+        its(:pseudo_iban) { is_expected.to eq("CAZZ003600063012345678900") }
+
+        # ibandit account number length validation can check for maximum
+        # length but not against a range, say, 7 to 12 digits, allowed in CA.
+        #
+        # given we are only going to deal with pseudo-IBANs in CA, choosing to
+        # not complete IBAN validation unless we need it.
+        #
+        its(:iban) { is_expected.to be_nil }
+        its(:valid?) { is_expected.to eq(true) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+    end
+
+    context "when the IBAN was created from an Canadian pseudo-IBAN" do
+      let(:arg) { "CAZZ0036000630123456" }
+
+      its(:country_code) { is_expected.to eq("CA") }
+      its(:bank_code) { is_expected.to eq("0036") }
+      its(:branch_code) { is_expected.to eq("00063") }
+      its(:account_number) { is_expected.to eq("0123456") }
+      its(:swift_bank_code) { is_expected.to eq("0036") }
+      its(:swift_branch_code) { is_expected.to eq("00063") }
+      its(:swift_account_number) { is_expected.to eq("0123456") }
+      its(:pseudo_iban) { is_expected.to eq("CAZZ003600063_____0123456") }
+
+      # ibandit account number length validation can check for maximum
+      # length but not against a range, say, 7 to 12 digits, allowed in CA.
+      #
+      # given we are only going to deal with pseudo-IBANs in CA, choosing to
+      # not complete IBAN validation unless we need it.
+      #
+      its(:iban) { is_expected.to be_nil }
+      its(:valid?) { is_expected.to eq(false) }
+      its(:to_s) { is_expected.to eq("") }
+    end
+
+    context "when the input is an invalid Canadan pseudo-IBAN" do
+      let(:arg) { "CAZZ00360006301234" }
+
+      it "is invalid and has the correct errors" do
+        expect(subject.valid?).to eq(false)
+        expect(subject.errors).
+          to eq(account_number: "is the wrong length (should be 12 characters)")
+      end
+    end
+
     context "when the IBAN was created with local details for New Zealand" do
       let(:arg) do
         {

--- a/spec/ibandit/pseudo_iban_assembler_spec.rb
+++ b/spec/ibandit/pseudo_iban_assembler_spec.rb
@@ -138,6 +138,57 @@ describe Ibandit::PseudoIBANAssembler do
     end
   end
 
+  context "for Canada" do
+    context "with valid parameters" do
+      let(:local_details) do
+        {
+          country_code: "CA",
+          bank_code: "0036",
+          branch_code: "00063",
+          account_number: "0123456",
+        }
+      end
+
+      it { is_expected.to eq("CAZZ003600063_____0123456") }
+    end
+
+    context "without a bank_code" do
+      let(:local_details) do
+        {
+          country_code: "CA",
+          branch_code: "00063",
+          account_number: "0123456",
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "without a branch code" do
+      let(:local_details) do
+        {
+          country_code: "CA",
+          bank_code: "0036",
+          account_number: "0123456",
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "without an account number" do
+      let(:local_details) do
+        {
+          country_code: "CA",
+          bank_code: "0036",
+          branch_code: "00063",
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   context "for a country that does not have pseudo-IBANs" do
     let(:local_details) do
       {

--- a/spec/ibandit/pseudo_iban_splitter_spec.rb
+++ b/spec/ibandit/pseudo_iban_splitter_spec.rb
@@ -68,5 +68,32 @@ describe Ibandit::PseudoIBANSplitter do
       its([:branch_code]) { is_expected.to eq("123456") }
       its([:account_number]) { is_expected.to eq("X123456789") }
     end
+
+    context "for a canadian pseudo-IBAN without padding" do
+      let(:pseudo_iban) { "CAZZ0036000630123456" }
+
+      its([:country_code]) { is_expected.to eq("CA") }
+      its([:bank_code]) { is_expected.to eq("0036") }
+      its([:branch_code]) { is_expected.to eq("00063") }
+      its([:account_number]) { is_expected.to eq("0123456") }
+    end
+
+    context "for a canadian pseudo-IBAN with padding" do
+      let(:pseudo_iban) { "CAZZ003600063_____0123456" }
+
+      its([:country_code]) { is_expected.to eq("CA") }
+      its([:bank_code]) { is_expected.to eq("0036") }
+      its([:branch_code]) { is_expected.to eq("00063") }
+      its([:account_number]) { is_expected.to eq("0123456") }
+    end
+
+    context "for a canadian pseudo-IBAN with a 12-digit account number" do
+      let(:pseudo_iban) { "CAZZ003600063012345678900" }
+
+      its([:country_code]) { is_expected.to eq("CA") }
+      its([:bank_code]) { is_expected.to eq("0036") }
+      its([:branch_code]) { is_expected.to eq("00063") }
+      its([:account_number]) { is_expected.to eq("012345678900") }
+    end
   end
 end


### PR DESCRIPTION
https://gocardless.myjetbrains.com/youtrack/issue/BANKINT-147

#### Splitting and assembling CA pseudo-IBAN

`CAZZ0036000630123456` will be split to:
```rb
country_code: CA
bank_code: 0036
branch_code: 00063
account_number: 0123456
```
... and assembled the other way round.

#### Note about IBAN validation

**this generates a valid pseudo-IBAN for the purpose of the linked ticket,
but IBAN validation will fail.**

ibandit account number length validation can check for maximum length but not against a range, say, 7 to 12 digits, allowed in CA. given we are only going to deal with pseudo-IBANs in CA, choosing to not complete IBAN validation unless we need it.

#### Note to reviewer

i'll bump the version number and update the Changelog once i get a 👍 on these changes.