### PR TITLE
Generate valid IBANs for Canada

### DIFF
--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -85,7 +85,9 @@ module Ibandit
     end
 
     def self.clean_ca_details(local_details)
-      local_details
+      return {} if local_details[:account_number].length < 7 # minimum length
+
+      { account_number: local_details[:account_number].rjust(12, "0") }
     end
 
     def self.clean_bg_details(local_details)

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -374,20 +374,14 @@ describe Ibandit::IBAN do
         its(:country_code) { is_expected.to eq("CA") }
         its(:bank_code) { is_expected.to eq("0036") }
         its(:branch_code) { is_expected.to eq("00063") }
-        its(:account_number) { is_expected.to eq("0123456") }
+        its(:account_number) { is_expected.to eq("000000123456") }
         its(:swift_bank_code) { is_expected.to eq("0036") }
         its(:swift_branch_code) { is_expected.to eq("00063") }
-        its(:swift_account_number) { is_expected.to eq("0123456") }
-        its(:pseudo_iban) { is_expected.to eq("CAZZ003600063_____0123456") }
+        its(:swift_account_number) { is_expected.to eq("000000123456") }
+        its(:pseudo_iban) { is_expected.to eq("CAZZ003600063000000123456") }
 
-        # ibandit account number length validation can check for maximum
-        # length but not against a range, say, 7 to 12 digits, allowed in CA.
-        #
-        # given we are only going to deal with pseudo-IBANs in CA, choosing to
-        # not complete IBAN validation unless we need it.
-        #
         its(:iban) { is_expected.to be_nil }
-        its(:valid?) { is_expected.to eq(false) }
+        its(:valid?) { is_expected.to eq(true) }
         its(:to_s) { is_expected.to eq("") }
       end
 
@@ -403,14 +397,8 @@ describe Ibandit::IBAN do
         its(:swift_account_number) { is_expected.to eq("012345678900") }
         its(:pseudo_iban) { is_expected.to eq("CAZZ003600063012345678900") }
 
-        # ibandit account number length validation can check for maximum
-        # length but not against a range, say, 7 to 12 digits, allowed in CA.
-        #
-        # given we are only going to deal with pseudo-IBANs in CA, choosing to
-        # not complete IBAN validation unless we need it.
-        #
         its(:iban) { is_expected.to be_nil }
-        its(:valid?) { is_expected.to eq(true) }
+        its(:valid?) { is_expected.to be true }
         its(:to_s) { is_expected.to eq("") }
       end
     end
@@ -421,24 +409,18 @@ describe Ibandit::IBAN do
       its(:country_code) { is_expected.to eq("CA") }
       its(:bank_code) { is_expected.to eq("0036") }
       its(:branch_code) { is_expected.to eq("00063") }
-      its(:account_number) { is_expected.to eq("0123456") }
+      its(:account_number) { is_expected.to eq("000000123456") }
       its(:swift_bank_code) { is_expected.to eq("0036") }
       its(:swift_branch_code) { is_expected.to eq("00063") }
-      its(:swift_account_number) { is_expected.to eq("0123456") }
-      its(:pseudo_iban) { is_expected.to eq("CAZZ003600063_____0123456") }
+      its(:swift_account_number) { is_expected.to eq("000000123456") }
+      its(:pseudo_iban) { is_expected.to eq("CAZZ003600063000000123456") }
 
-      # ibandit account number length validation can check for maximum
-      # length but not against a range, say, 7 to 12 digits, allowed in CA.
-      #
-      # given we are only going to deal with pseudo-IBANs in CA, choosing to
-      # not complete IBAN validation unless we need it.
-      #
       its(:iban) { is_expected.to be_nil }
-      its(:valid?) { is_expected.to eq(false) }
+      its(:valid?) { is_expected.to be true }
       its(:to_s) { is_expected.to eq("") }
     end
 
-    context "when the input is an invalid Canadan pseudo-IBAN" do
+    context "when the input is an invalid Canadian pseudo-IBAN" do
       let(:arg) { "CAZZ00360006301234" }
 
       it "is invalid and has the correct errors" do

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -141,6 +141,18 @@ describe Ibandit::LocalDetailsCleaner do
     end
   end
 
+  context "Canada" do
+    let(:country_code) { "CA" }
+    let(:account_number) { "0123456" }
+    let(:bank_code) { "0036" }
+    let(:branch_code) { "00063" }
+
+    its([:account_number]) { is_expected.to eq("000000123456") }
+    its([:country_code]) { is_expected.to eq(country_code) }
+    its([:bank_code]) { is_expected.to eq("0036") }
+    its([:branch_code]) { is_expected.to eq("00063") }
+  end
+
   context "Cyprus" do
     let(:country_code) { "CY" }
     let(:account_number) { "0000001200527600" }


### PR DESCRIPTION
https://gocardless.myjetbrains.com/youtrack/issue/BANKINT-147
follow-up to: https://github.com/gocardless/ibandit/pull/112

### Context

- Canadian account numbers can be between 7 to 12 digits long.
- ibandit supports validating account numbers being of a fixed length, and doesn't support validating against a range.
- Hence, as a workaround, we pad 0s to any account number shorter than 12 characters, but longer than 7, before validating against an expected length of 12.

### Assumption

- we [return account numbers that are 12 digits long even when they are shorter in real](https://github.com/gocardless/ibandit/blob/cb4f9aacdf1c7f634d671e6b293a46205d311ee5/spec/ibandit/iban_spec.rb#L377), by padding 0s. this keeps it consistent with how we do it for Australia where the account numbers can be of a variable length. the other more elaborate solution is to build support for account number length validation in a range.