### PR TITLE
Validate branch codes for Canadian PseudoIBANs

### DIFF
--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -283,6 +283,7 @@ module Ibandit
       when "SE" then valid_swedish_details?
       when "AU" then valid_australian_details?
       when "NZ" then valid_nz_details?
+      when "CA" then valid_ca_details?
       else true
       end
     end
@@ -357,6 +358,13 @@ module Ibandit
 
     def valid_nz_details?
       return true unless country_code == "NZ"
+      return true unless Ibandit.modulus_checker
+
+      valid_modulus_check_branch_code?
+    end
+
+    def valid_ca_details?
+      return true unless country_code == "CA"
       return true unless Ibandit.modulus_checker
 
       valid_modulus_check_branch_code?


### PR DESCRIPTION
The [Financial Institutions File](https://www.payments.ca/our-directories/financial-institutions-file) provided by Payments Canada can be used to validate the existence of a specified bank branch in Canada. This check can be carried out as part of the branch_code_check in Ibandit's configured modulus checker.

Here, we extend the country-specific validation checks for Canadian pseudoIBANs to cover the validation of branch codes (if a configured modulus checker exists).