### PR TITLE
Prevent all-zero account numbers in Australia

### DIFF
--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -373,7 +373,7 @@ module Ibandit
     def valid_australian_details?
       return true unless country_code == "AU"
 
-      bsb_check?
+      bsb_check? && account_number_not_all_zeros?
     end
 
     def bsb_check?
@@ -511,6 +511,13 @@ module Ibandit
     def pseudo_iban?(input)
       return false if input.nil?
       input.slice(2, 2) == Constants::PSEUDO_IBAN_CHECK_DIGITS
+    end
+
+    def account_number_not_all_zeros?
+      return true if @swift_account_number.to_s.chars.uniq != ["0"]
+
+      @errors[:account_number] = Ibandit.translate(:is_invalid)
+      false
     end
   end
 end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -273,6 +273,23 @@ describe Ibandit::IBAN do
         its(:valid?) { is_expected.to eq(true) }
         its(:to_s) { is_expected.to eq("") }
       end
+
+      context "and an account number that is all zero" do
+        let(:account_number) { "000000" }
+
+        its(:country_code) { is_expected.to eq("AU") }
+        its(:bank_code) { is_expected.to be_nil }
+        its(:branch_code) { is_expected.to eq("123456") }
+        its(:account_number) { is_expected.to eq("0000000000") }
+        its(:swift_bank_code) { is_expected.to be_nil }
+        its(:swift_branch_code) { is_expected.to eq("123456") }
+        its(:swift_account_number) { is_expected.to eq("0000000000") }
+        its(:swift_national_id) { is_expected.to eq("123456") }
+        its(:iban) { is_expected.to be_nil }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ1234560000000000") }
+        its(:valid?) { is_expected.to eq(false) }
+        its(:to_s) { is_expected.to eq("") }
+      end
     end
 
     context "when the IBAN was created from an Australian pseudo-IBAN" do


### PR DESCRIPTION
Account numbers cannot be all-zero in Australia.

This PR prevents account numbers that are all-zero from passing validation. Currently this has not been ported to any other countries - this can be done case-by-case.