### PR TITLE
Make travis work again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ rvm:
 
 sudo: false
 
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
+
 script:
   - bundle exec rubocop
   - bundle exec rspec spec


### PR DESCRIPTION
It will by default install bundler >= 2.0 which is currently not supported.