### PR TITLE
🇺🇸Pseudo-IBAN split/assemble support for US

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ For example:
 | Spain           | :white_check_mark:           | :white_check_mark: |                    |
 | Sweden          | :white_check_mark:           |                    | :white_check_mark: |
 | United Kingdom  | :white_check_mark:           | :white_check_mark: |                    |
+| USA             |                              |                    | :white_check_mark: |
 
 ## Usage
 

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -897,3 +897,14 @@ CA:
   :pseudo_iban_bank_code_length: 4
   :pseudo_iban_branch_code_length: 5
   :pseudo_iban_account_number_length: 12
+US:
+  :bank_code_length: 9
+  :branch_code_length: 0
+  :account_number_length: 17
+  :bank_code_format: "\\d{9}"
+  # TODO: update account number format based on inputs from user research
+  :account_number_format: ".{1,17}"
+  :national_id_length: 9
+  :pseudo_iban_bank_code_length: 9
+  :pseudo_iban_branch_code_length: 0
+  :pseudo_iban_account_number_length: 17

--- a/lib/ibandit/constants.rb
+++ b/lib/ibandit/constants.rb
@@ -4,7 +4,7 @@ module Ibandit
                                           HR HU IE IS IT LT LU LV MC MT NL NO PL
                                           PT RO SE SI SK SM].freeze
 
-    PSEUDO_IBAN_COUNTRY_CODES = %w[AU SE NZ CA].freeze
+    PSEUDO_IBAN_COUNTRY_CODES = %w[AU SE NZ CA US].freeze
     DECONSTRUCTABLE_IBAN_COUNTRY_CODES =
       CONSTRUCTABLE_IBAN_COUNTRY_CODES - PSEUDO_IBAN_COUNTRY_CODES
 
@@ -15,6 +15,7 @@ module Ibandit
       "AU" => "_", # Using _ because AU account numbers are alphanumeric
       "NZ" => "_",
       "CA" => "_",
+      "US" => "_",
     }.freeze
 
     SUPPORTED_COUNTRY_CODES = (

--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -284,6 +284,7 @@ module Ibandit
       when "AU" then valid_australian_details?
       when "NZ" then valid_nz_details?
       when "CA" then valid_ca_details?
+      when "US" then bank_code_passes_checksum_test?
       else true
       end
     end
@@ -382,6 +383,24 @@ module Ibandit
 
       valid_modulus_check_branch_code?
     end
+
+    # rubocop:disable Metrics/AbcSize
+    def bank_code_passes_checksum_test?
+      return false if swift_bank_code.length != 9
+
+      code_digits = swift_bank_code.chars.map(&:to_i)
+      mod =
+        (
+          3 * (code_digits[0] + code_digits[3] + code_digits[6]) +
+          7 * (code_digits[1] + code_digits[4] + code_digits[7]) +
+          1 * (code_digits[2] + code_digits[5] + code_digits[8])
+        ) % 10
+
+      @errors[:bank_code] = Ibandit.translate(:is_invalid) unless mod.zero?
+
+      mod.zero?
+    end
+    # rubocop:enable Metrics/AbcSize
 
     ###################
     # Private methods #

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -32,7 +32,8 @@ module Ibandit
 
     def self.required_fields(country_code)
       case country_code
-      when "AT", "CY", "DE", "FI", "LT", "LU", "LV", "NL", "RO", "SI", "SK"
+      when "AT", "CY", "DE", "FI", "LT", "LU",
+            "LV", "NL", "RO", "SI", "SK", "US"
         %i[bank_code account_number]
       when "BE", "CZ", "DK", "EE", "ES", "HR",
             "HU", "IS", "NO", "PL", "SE", "NZ"
@@ -96,6 +97,18 @@ module Ibandit
       {
         account_number: local_details[:account_number].rjust(12, "0"),
         bank_code: bank_code,
+      }
+    end
+
+    def self.clean_us_details(local_details)
+      return {} unless local_details[:bank_code].length == 9
+
+      account_number = local_details[:account_number].delete(" ")
+      return {} unless (1..17).cover?(account_number.length)
+
+      {
+        bank_code: local_details[:bank_code],
+        account_number: account_number.rjust(17, "_"),
       }
     end
 

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -612,7 +612,7 @@ describe Ibandit::IBAN do
       end
 
       context "and a 9 digit bank code" do
-        let(:bank_code) { "012345678" }
+        let(:bank_code) { "965498456" }
         let(:account_number) { "01234567890123456" }
 
         its(:country_code) { is_expected.to eq("US") }
@@ -623,7 +623,7 @@ describe Ibandit::IBAN do
         its(:swift_account_number) { is_expected.to eq(account_number) }
         its(:swift_national_id) { is_expected.to eq(bank_code) }
         its(:pseudo_iban) do
-          is_expected.to eq("USZZ01234567801234567890123456")
+          is_expected.to eq("USZZ96549845601234567890123456")
         end
 
         its(:iban) { is_expected.to be_nil }
@@ -651,9 +651,21 @@ describe Ibandit::IBAN do
         its(:to_s) { is_expected.to eq("") }
       end
 
+      context "and bank code that doesn't pass checksum test" do
+        let(:bank_code) { "900000000" }
+        let(:account_number) { "01234567890123456" }
+
+        its(:iban) { is_expected.to be_nil }
+
+        it "returns an error on bank_code attribute" do
+          expect(subject.valid?).to eq(false)
+          expect(subject.errors).to eq(bank_code: "is invalid")
+        end
+      end
+
       context "and a 7 digit account number" do
         let(:account_number) { "0123456" }
-        let(:bank_code) { "012345678" }
+        let(:bank_code) { "965498456" }
 
         its(:country_code) { is_expected.to eq("US") }
         its(:bank_code) { is_expected.to eq(bank_code) }
@@ -663,7 +675,7 @@ describe Ibandit::IBAN do
         its(:swift_account_number) { is_expected.to eq("__________0123456") }
         its(:swift_national_id) { is_expected.to eq(bank_code) }
         its(:pseudo_iban) do
-          is_expected.to eq("USZZ012345678__________0123456")
+          is_expected.to eq("USZZ965498456__________0123456")
         end
 
         its(:iban) { is_expected.to be_nil }
@@ -673,7 +685,7 @@ describe Ibandit::IBAN do
 
       context "and a 17 digit account number" do
         let(:account_number) { "01234567890123456" }
-        let(:bank_code) { "012345678" }
+        let(:bank_code) { "965498456" }
 
         its(:country_code) { is_expected.to eq("US") }
         its(:bank_code) { is_expected.to eq(bank_code) }
@@ -683,7 +695,7 @@ describe Ibandit::IBAN do
         its(:swift_account_number) { is_expected.to eq(account_number) }
         its(:swift_national_id) { is_expected.to eq(bank_code) }
         its(:pseudo_iban) do
-          is_expected.to eq("USZZ01234567801234567890123456")
+          is_expected.to eq("USZZ96549845601234567890123456")
         end
 
         its(:iban) { is_expected.to be_nil }
@@ -693,18 +705,18 @@ describe Ibandit::IBAN do
     end
 
     context "when the IBAN was created from a US pseudo-IBAN" do
-      let(:arg) { "USZZ01234567801234567890123456" }
+      let(:arg) { "USZZ96549845601234567890123456" }
 
       its(:country_code) { is_expected.to eq("US") }
-      its(:bank_code) { is_expected.to eq("012345678") }
+      its(:bank_code) { is_expected.to eq("965498456") }
       its(:branch_code) { is_expected.to be_nil }
       its(:account_number) { is_expected.to eq("01234567890123456") }
-      its(:swift_bank_code) { is_expected.to eq("012345678") }
+      its(:swift_bank_code) { is_expected.to eq("965498456") }
       its(:swift_branch_code) { is_expected.to eq(nil) }
       its(:swift_account_number) { is_expected.to eq("01234567890123456") }
-      its(:swift_national_id) { is_expected.to eq("012345678") }
+      its(:swift_national_id) { is_expected.to eq("965498456") }
       its(:pseudo_iban) do
-        is_expected.to eq("USZZ01234567801234567890123456")
+        is_expected.to eq("USZZ96549845601234567890123456")
       end
 
       its(:iban) { is_expected.to be_nil }

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -601,6 +601,126 @@ describe Ibandit::IBAN do
           to eq(account_number: "is the wrong length (should be 10 characters)")
       end
     end
+
+    context "when the IBAN was created with local details for US" do
+      let(:arg) do
+        {
+          country_code: "US",
+          bank_code: bank_code,
+          account_number: account_number,
+        }
+      end
+
+      context "and a 9 digit bank code" do
+        let(:bank_code) { "012345678" }
+        let(:account_number) { "01234567890123456" }
+
+        its(:country_code) { is_expected.to eq("US") }
+        its(:bank_code) { is_expected.to eq(bank_code) }
+        its(:account_number) { is_expected.to eq(account_number) }
+        its(:swift_bank_code) { is_expected.to eq(bank_code) }
+        its(:swift_branch_code) { is_expected.to eq(nil) }
+        its(:swift_account_number) { is_expected.to eq(account_number) }
+        its(:swift_national_id) { is_expected.to eq(bank_code) }
+        its(:pseudo_iban) do
+          is_expected.to eq("USZZ01234567801234567890123456")
+        end
+
+        its(:iban) { is_expected.to be_nil }
+        its(:valid?) { is_expected.to eq(true) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+
+      context "and a 7 digit bank code" do
+        let(:bank_code) { "0123456" }
+        let(:account_number) { "01234567890123456" }
+
+        its(:country_code) { is_expected.to eq("US") }
+        its(:bank_code) { is_expected.to eq(bank_code) }
+        its(:account_number) { is_expected.to eq(account_number) }
+        its(:swift_bank_code) { is_expected.to eq(bank_code) }
+        its(:swift_branch_code) { is_expected.to eq(nil) }
+        its(:swift_account_number) { is_expected.to eq(account_number) }
+        its(:swift_national_id) { is_expected.to eq(bank_code) }
+        its(:pseudo_iban) do
+          is_expected.to eq("USZZ__012345601234567890123456")
+        end
+
+        its(:iban) { is_expected.to be_nil }
+        its(:valid?) { is_expected.to eq(false) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+
+      context "and a 7 digit account number" do
+        let(:account_number) { "0123456" }
+        let(:bank_code) { "012345678" }
+
+        its(:country_code) { is_expected.to eq("US") }
+        its(:bank_code) { is_expected.to eq(bank_code) }
+        its(:account_number) { is_expected.to eq("__________0123456") }
+        its(:swift_bank_code) { is_expected.to eq(bank_code) }
+        its(:swift_branch_code) { is_expected.to eq(nil) }
+        its(:swift_account_number) { is_expected.to eq("__________0123456") }
+        its(:swift_national_id) { is_expected.to eq(bank_code) }
+        its(:pseudo_iban) do
+          is_expected.to eq("USZZ012345678__________0123456")
+        end
+
+        its(:iban) { is_expected.to be_nil }
+        its(:valid?) { is_expected.to eq(true) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+
+      context "and a 17 digit account number" do
+        let(:account_number) { "01234567890123456" }
+        let(:bank_code) { "012345678" }
+
+        its(:country_code) { is_expected.to eq("US") }
+        its(:bank_code) { is_expected.to eq(bank_code) }
+        its(:account_number) { is_expected.to eq("01234567890123456") }
+        its(:swift_bank_code) { is_expected.to eq(bank_code) }
+        its(:swift_branch_code) { is_expected.to eq(nil) }
+        its(:swift_account_number) { is_expected.to eq(account_number) }
+        its(:swift_national_id) { is_expected.to eq(bank_code) }
+        its(:pseudo_iban) do
+          is_expected.to eq("USZZ01234567801234567890123456")
+        end
+
+        its(:iban) { is_expected.to be_nil }
+        its(:valid?) { is_expected.to be true }
+        its(:to_s) { is_expected.to eq("") }
+      end
+    end
+
+    context "when the IBAN was created from a US pseudo-IBAN" do
+      let(:arg) { "USZZ01234567801234567890123456" }
+
+      its(:country_code) { is_expected.to eq("US") }
+      its(:bank_code) { is_expected.to eq("012345678") }
+      its(:branch_code) { is_expected.to be_nil }
+      its(:account_number) { is_expected.to eq("01234567890123456") }
+      its(:swift_bank_code) { is_expected.to eq("012345678") }
+      its(:swift_branch_code) { is_expected.to eq(nil) }
+      its(:swift_account_number) { is_expected.to eq("01234567890123456") }
+      its(:swift_national_id) { is_expected.to eq("012345678") }
+      its(:pseudo_iban) do
+        is_expected.to eq("USZZ01234567801234567890123456")
+      end
+
+      its(:iban) { is_expected.to be_nil }
+      its(:valid?) { is_expected.to be true }
+      its(:to_s) { is_expected.to eq("") }
+    end
+
+    context "when the input is an invalid US pseudo-IBAN" do
+      let(:arg) { "USZZ__012345601234567890123456" }
+
+      it "is invalid and has the correct errors" do
+        expect(subject.valid?).to eq(false)
+        expect(subject.errors).
+          to eq(bank_code: "is the wrong length (should be 9 characters)")
+      end
+    end
   end
 
   describe "#to_s" do

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -1158,4 +1158,24 @@ describe Ibandit::LocalDetailsCleaner do
       it { is_expected.to eq(local_details_with_swift) }
     end
   end
+
+  context "US" do
+    context "when the account number has space characters" do
+      let(:country_code) { "US" }
+      let(:bank_code) { "012345678" }
+      let(:account_number) { "0123-45678 1234567" }
+
+      its([:bank_code]) { is_expected.to eq(bank_code) }
+      its([:account_number]) { is_expected.to eq("0123-456781234567") }
+    end
+
+    context "when the account number is shorter than the maximum length" do
+      let(:country_code) { "US" }
+      let(:bank_code) { "012345678" }
+      let(:account_number) { "0123456789" }
+
+      its([:bank_code]) { is_expected.to eq(bank_code) }
+      its([:account_number]) { is_expected.to eq("_______0123456789") }
+    end
+  end
 end

--- a/spec/ibandit/pseudo_iban_assembler_spec.rb
+++ b/spec/ibandit/pseudo_iban_assembler_spec.rb
@@ -189,6 +189,42 @@ describe Ibandit::PseudoIBANAssembler do
     end
   end
 
+  context "for US" do
+    context "with valid parameters" do
+      let(:local_details) do
+        {
+          country_code: "US",
+          bank_code: "012345678",
+          account_number: "01234567890123456",
+        }
+      end
+
+      it { is_expected.to eq("USZZ01234567801234567890123456") }
+    end
+
+    context "without a bank_code" do
+      let(:local_details) do
+        {
+          country_code: "US",
+          account_number: "01234567890123456",
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "without an account number" do
+      let(:local_details) do
+        {
+          country_code: "US",
+          bank_code: "012345678",
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   context "for a country that does not have pseudo-IBANs" do
     let(:local_details) do
       {

--- a/spec/ibandit/pseudo_iban_splitter_spec.rb
+++ b/spec/ibandit/pseudo_iban_splitter_spec.rb
@@ -95,5 +95,29 @@ describe Ibandit::PseudoIBANSplitter do
       its([:branch_code]) { is_expected.to eq("00063") }
       its([:account_number]) { is_expected.to eq("012345678900") }
     end
+
+    context "for a US pseudo-IBAN without padding" do
+      let(:pseudo_iban) { "USZZ0123456780123456" }
+
+      its([:country_code]) { is_expected.to eq("US") }
+      its([:bank_code]) { is_expected.to eq("012345678") }
+      its([:account_number]) { is_expected.to eq("0123456") }
+    end
+
+    context "for a US pseudo-IBAN with padding" do
+      let(:pseudo_iban) { "USZZ012345678__________0123456" }
+
+      its([:country_code]) { is_expected.to eq("US") }
+      its([:bank_code]) { is_expected.to eq("012345678") }
+      its([:account_number]) { is_expected.to eq("0123456") }
+    end
+
+    context "for a US pseudo-IBAN with a 17-digit account number" do
+      let(:pseudo_iban) { "USZZ01234567801234567890123456" }
+
+      its([:country_code]) { is_expected.to eq("US") }
+      its([:bank_code]) { is_expected.to eq("012345678") }
+      its([:account_number]) { is_expected.to eq("01234567890123456") }
+    end
   end
 end


### PR DESCRIPTION
### Splitting and assembling US pseudo-IBANs

`USZZ01234567801234567890123456` will be split to:

country_code: `US`
bank_code (routing number, 9-digits fixed length): `012345678`
account_number (upto 17-characters): `01234567890123456`

... and assembled the other way round.

### Changes here

- defined structure of US pseudo-IBAN
- updated local details cleaner to remove spaces in account numbers as per NACHA guidelines
- validating only length of account number, not format, that's pending inputs from user research