### PR TITLE
Allow digits only in US ACH account numbers

### DIFF
--- a/data/structures.yml
+++ b/data/structures.yml
@@ -902,8 +902,7 @@ US:
   :branch_code_length: 0
   :account_number_length: 17
   :bank_code_format: "\\d{9}"
-  # TODO: update account number format based on inputs from user research
-  :account_number_format: ".{1,17}"
+  :account_number_format: "\\A_*\\d{1,17}\\z"
   :national_id_length: 9
   :pseudo_iban_bank_code_length: 9
   :pseudo_iban_branch_code_length: 0

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -724,13 +724,22 @@ describe Ibandit::IBAN do
       its(:to_s) { is_expected.to eq("") }
     end
 
-    context "when the input is an invalid US pseudo-IBAN" do
+    context "when the input pseudo-IBAN has an invalid US bank_code" do
       let(:arg) { "USZZ__012345601234567890123456" }
 
       it "is invalid and has the correct errors" do
         expect(subject.valid?).to eq(false)
         expect(subject.errors).
           to eq(bank_code: "is the wrong length (should be 9 characters)")
+      end
+    end
+
+    context "when the input pseudo-IBAN has an invalid US account_number" do
+      let(:arg) { "USZZ965498456ABC01234567890123" }
+
+      it "is invalid and has an error populated" do
+        expect(subject.valid?).to eq(false)
+        expect(subject.errors).to eq(account_number: "is invalid")
       end
     end
   end


### PR DESCRIPTION
### Background

As per NACHA, US ACH account numbers can contain alphabetical characters, digits, and certain symbols as well. However, we would like to restrict to digits-only because our users are likely to have digit-only account numbers and we operate on the ACH network where digits-only are appropriate (from what we've learned, other account numbers are used by US banks for internal routing, than allocating to their customers).

### Note to reviewer

The [validation rule](https://github.com/gocardless/ibandit/blob/d5a4b975b75396468720c07780d5e0eeed66551b/data/structures.yml#L905) allows an underscore because that's [the padding character for US account numbers shorter than 17 digits](https://github.com/gocardless/ibandit/blob/d5a4b975b75396468720c07780d5e0eeed66551b/lib/ibandit/constants.rb#L18), but that's OK to allow because [we remove leading padding characters at a later stage](https://github.com/gocardless/ibandit/blob/d5a4b975b75396468720c07780d5e0eeed66551b/lib/ibandit/pseudo_iban_splitter.rb#L75-L78) before submitting an account number to the bank.