### PR TITLE
Bump version to 0.11.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.27 - February 22, 2019
+
+- Update US account number format validation to allow digits-only
+
 ## 0.11.26 - January 30, 2019
 
 - Add support for US pseudo-IBANs

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,3 +1,3 @@
 module Ibandit
-  VERSION = "0.11.26".freeze
+  VERSION = "0.11.27".freeze
 end


### PR DESCRIPTION
Releases:
 - [Allow digits only in US ACH account numbers](https://github.com/gocardless/ibandit/pull/137)