### PR TITLE
Handle when bank_code is nil gracefully

### DIFF
--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -386,6 +386,7 @@ module Ibandit
 
     # rubocop:disable Metrics/AbcSize
     def bank_code_passes_checksum_test?
+      return false unless swift_bank_code
       return false if swift_bank_code.length != 9
 
       code_digits = swift_bank_code.chars.map(&:to_i)

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -683,6 +683,18 @@ describe Ibandit::IBAN do
         its(:to_s) { is_expected.to eq("") }
       end
 
+      context "and bank code that is nil" do
+        let(:bank_code) { nil }
+        let(:account_number) { "01234567890123456" }
+
+        its(:iban) { is_expected.to be_nil }
+
+        it "returns an error on bank_code attribute" do
+          expect(subject.valid?).to eq(false)
+          expect(subject.errors).to eq(bank_code: "is required")
+        end
+      end
+
       context "and a 17 digit account number" do
         let(:account_number) { "01234567890123456" }
         let(:bank_code) { "965498456" }


### PR DESCRIPTION
We currently raise a `NoMethodError` when `nil` is passed in as a `bank_code` which isn't very graceful.

Instead, we should be failing the validation with an error that indicates that this is required.