### PR TITLE
Update tested ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ matrix:
   allow_failures:
 
 rvm:
-  - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.4
+  - 2.5
+  - 2.6
+
 
 sudo: false
 


### PR DESCRIPTION
2.1, 2.2 & 2.3 are past end of life so we shouldn't be aiming to support them.
But we should be testing against newer ruby versions.