### PR TITLE
Tighten up validation for account numbers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,3 +43,8 @@ Metrics/ModuleLength:
 
 Layout/DotPosition:
   EnforcedStyle: 'trailing'
+
+# Wants to to lock to Ruby 2.4 as specified here but as this is a public gem
+# this is quite aggressive.
+Gemspec/RequiredRubyVersion:
+  Enabled: false

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -892,7 +892,7 @@ CA:
   :account_number_length: 12
   :bank_code_format: "\\d{4}"
   :branch_code_format: "\\d{5}"
-  :account_number_format: "\\d{7,12}"
+  :account_number_format: "\\A\\d{7,12}\\z"
   :national_id_length: 4
   :pseudo_iban_bank_code_length: 4
   :pseudo_iban_branch_code_length: 5

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -95,7 +95,7 @@ BE:
   :national_id_length: 3
   :bban_format: "\\d{3}\\d{7}\\d{2}"
   :bank_code_format: "\\d{3}"
-  :account_number_format: "\\d{7}\\d{2}"
+  :account_number_format: "\\d{7}\\d{2}\\d{3}"
   :local_check_digit_position: 15
   :local_check_digit_length: 2
 BG:
@@ -892,7 +892,7 @@ CA:
   :account_number_length: 12
   :bank_code_format: "\\d{4}"
   :branch_code_format: "\\d{5}"
-  :account_number_format: "\\A\\d{7,12}\\z"
+  :account_number_format: "\\d{7,12}"
   :national_id_length: 4
   :pseudo_iban_bank_code_length: 4
   :pseudo_iban_branch_code_length: 5
@@ -902,7 +902,7 @@ US:
   :branch_code_length: 0
   :account_number_length: 17
   :bank_code_format: "\\d{9}"
-  :account_number_format: "\\A_*\\d{1,17}\\z"
+  :account_number_format: "_*\\d{1,17}"
   :national_id_length: 9
   :pseudo_iban_bank_code_length: 9
   :pseudo_iban_branch_code_length: 0

--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -225,7 +225,7 @@ module Ibandit
       return unless valid_country_code?
       return unless structure[:bban_format]
 
-      if bban&.match?(Regexp.new(structure[:bban_format]))
+      if bban&.match?(entire_string_regex(structure[:bban_format]))
         true
       else
         @errors[:format] = Ibandit.translate(:invalid_format,
@@ -238,7 +238,9 @@ module Ibandit
       return unless valid_bank_code_length?
       return true if structure[:bank_code_length]&.zero?
 
-      if swift_bank_code&.match?(Regexp.new(structure[:bank_code_format]))
+      if swift_bank_code&.match?(
+        entire_string_regex(structure[:bank_code_format]),
+      )
         true
       else
         @errors[:bank_code] = Ibandit.translate(:is_invalid)
@@ -250,7 +252,9 @@ module Ibandit
       return unless valid_branch_code_length?
       return true unless structure[:branch_code_format]
 
-      if swift_branch_code&.match?(Regexp.new(structure[:branch_code_format]))
+      if swift_branch_code&.match?(
+        entire_string_regex(structure[:branch_code_format]),
+      )
         true
       else
         @errors[:branch_code] = Ibandit.translate(:is_invalid)
@@ -262,7 +266,7 @@ module Ibandit
       return unless valid_account_number_length?
 
       if swift_account_number&.match?(
-        Regexp.new(structure[:account_number_format]),
+        entire_string_regex(structure[:account_number_format]),
       )
         true
       else
@@ -497,6 +501,10 @@ module Ibandit
 
     def structure
       Ibandit.structures[country_code]
+    end
+
+    def entire_string_regex(pattern)
+      Regexp.new("\\A#{pattern}\\z")
     end
 
     def formatted

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -89,7 +89,9 @@ module Ibandit
     end
 
     def self.clean_ca_details(local_details)
-      return {} if local_details[:account_number].length < 7 # minimum length
+      account_number = local_details[:account_number].tr("-", "")
+
+      return {} if account_number.length < 7 # minimum length
 
       bank_code = if local_details[:bank_code].length == 3
                     local_details[:bank_code].rjust(4, "0")
@@ -98,7 +100,7 @@ module Ibandit
                   end
 
       {
-        account_number: local_details[:account_number].rjust(12, "0"),
+        account_number: account_number.rjust(12, "0"),
         bank_code: bank_code,
       }
     end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -112,6 +112,22 @@ describe Ibandit::IBAN do
       its(:local_check_digits) { is_expected.to be_nil }
     end
 
+    context "when the IBAN was created from a Belgian IBAN" do
+      let(:iban_code) { "BE62510007547061" }
+
+      its(:country_code) { is_expected.to eq("BE") }
+      its(:bank_code) { is_expected.to eq("510") }
+      its(:branch_code) { is_expected.to be_nil }
+      its(:account_number) { is_expected.to eq("510007547061") }
+      its(:account_number_suffix) { is_expected.to be_nil }
+      its(:swift_bank_code) { is_expected.to eq("510") }
+      its(:swift_branch_code) { is_expected.to be_nil }
+      its(:swift_account_number) { is_expected.to eq("510007547061") }
+      its(:swift_national_id) { is_expected.to eq("510") }
+      its(:local_check_digits) { is_expected.to eq("61") }
+      its(:bban) { is_expected.to eq("510007547061") }
+    end
+
     context "when the IBAN was created with local details" do
       let(:arg) do
         {

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -452,6 +452,13 @@ describe Ibandit::IBAN do
         its(:to_s) { is_expected.to eq("") }
       end
 
+      context "and account number has invalid characters in" do
+        let(:account_number) { "123456XX789" }
+        let(:bank_code) { "0036" }
+
+        its(:valid?) { is_expected.to be false }
+      end
+
       context "and a 12 digit account number" do
         let(:account_number) { "012345678900" }
         let(:bank_code) { "0036" }

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -167,6 +167,12 @@ describe Ibandit::LocalDetailsCleaner do
     its([:country_code]) { is_expected.to eq(country_code) }
     its([:bank_code]) { is_expected.to eq("0036") }
     its([:branch_code]) { is_expected.to eq("00063") }
+
+    context "with a hyphen" do
+      let(:account_number) { "0123456-789" }
+
+      its([:account_number]) { is_expected.to eq("000123456789") }
+    end
   end
 
   context "Cyprus" do


### PR DESCRIPTION
Previously this validation would allow account number formats in Canada like

- `1234567-789`
- `1234567-ABC`

This is because calling `Regex.match?` will return the first match it
sees rather than testing the entire string. So to fix this we use the
start and end of string matches to ensure the entire string is tested.