### PR TITLE
Correct swift national id for Canadian psudo ibans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0 - February 22, 2021
+
+- [Breaking] Correct `swift_national_id` for Canadian Psudo Ibans. Before `swift_national_id`
+  would return the institution code only. Now it returns the `{institution_code}{branch_code}` as
+  per the format for electronic transfers - `0YYYXXXXX`
+
 ## 1.3.0 - February 18, 2021
 
 - Add support for BY, EG, FO, IQ, LC, SC, UA and VA

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -997,7 +997,7 @@ CA:
   :bank_code_format: "\\d{4}"
   :branch_code_format: "\\d{5}"
   :account_number_format: "\\d{7,12}"
-  :national_id_length: 4
+  :national_id_length: 9
   :pseudo_iban_bank_code_length: 4
   :pseudo_iban_branch_code_length: 5
   :pseudo_iban_account_number_length: 12

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ibandit
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -422,7 +422,7 @@ describe Ibandit::IBAN do
         its(:swift_bank_code) { is_expected.to eq("0036") }
         its(:swift_branch_code) { is_expected.to eq("00063") }
         its(:swift_account_number) { is_expected.to eq("000000123456") }
-        its(:swift_national_id) { is_expected.to eq("0036") }
+        its(:swift_national_id) { is_expected.to eq("003600063") }
         its(:pseudo_iban) { is_expected.to eq("CAZZ003600063000000123456") }
 
         its(:iban) { is_expected.to be_nil }
@@ -441,7 +441,7 @@ describe Ibandit::IBAN do
         its(:swift_bank_code) { is_expected.to eq("36") }
         its(:swift_branch_code) { is_expected.to eq("00063") }
         its(:swift_account_number) { is_expected.to eq("000000123456") }
-        its(:swift_national_id) { is_expected.to eq("3600") }
+        its(:swift_national_id) { is_expected.to eq("3600063") }
         its(:pseudo_iban) { is_expected.to eq("CAZZ__3600063000000123456") }
 
         its(:iban) { is_expected.to be_nil }
@@ -460,7 +460,7 @@ describe Ibandit::IBAN do
         its(:swift_bank_code) { is_expected.to eq("0036") }
         its(:swift_branch_code) { is_expected.to eq("00063") }
         its(:swift_account_number) { is_expected.to eq("000000123456") }
-        its(:swift_national_id) { is_expected.to eq("0036") }
+        its(:swift_national_id) { is_expected.to eq("003600063") }
         its(:pseudo_iban) { is_expected.to eq("CAZZ003600063000000123456") }
 
         its(:iban) { is_expected.to be_nil }
@@ -486,7 +486,7 @@ describe Ibandit::IBAN do
         its(:swift_bank_code) { is_expected.to eq("0036") }
         its(:swift_branch_code) { is_expected.to eq("00063") }
         its(:swift_account_number) { is_expected.to eq("012345678900") }
-        its(:swift_national_id) { is_expected.to eq("0036") }
+        its(:swift_national_id) { is_expected.to eq("003600063") }
         its(:pseudo_iban) { is_expected.to eq("CAZZ003600063012345678900") }
 
         its(:iban) { is_expected.to be_nil }


### PR DESCRIPTION
Canadian routing numbers take the format of `institution_id-branch_code`. We were assuming that only the institution code was necessary to look up the bank's details however, we also need the branch code to differentiate between them.