### PR TITLE
Fix US and CA account number padding

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,9 +5,9 @@ inherit_gem:
 AllCops:
   TargetRubyVersion: 2.4
 
-# Limit lines to 80 characters.
+# Limit lines to 90 characters.
 Layout/LineLength:
-  Max: 80
+  Max: 90
 
 Metrics/ClassLength:
   Max: 400

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 1.5.0 - March 11, 2021
+
+- Fix issue with padding on Canadian and USA pseudo IBANs #198
+
 ## 1.4.1 - March 3, 2021
 
 - Update BLZ data - BLZVZ FTSEX MD 652
-
 
 ## 1.4.0 - February 22, 2021
 

--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ iban.iban                      # => nil
 iban = Ibandit::IBAN.new('USZZ026073150_______2715500356')
 iban.country_code              # => "US"
 iban.bank_code                 # => "026073150"
-iban.account_number            # => "_______2715500356"
+iban.account_number            # => "2715500356"
 iban.iban                      # => nil
 ```
 

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -993,7 +993,10 @@ AU:
 CA:
   :bank_code_length: 4
   :branch_code_length: 5
-  :account_number_length: 12
+  :account_number_length: !ruby/range
+    begin: 7
+    end: 12
+    excl: false
   :bank_code_format: "\\d{4}"
   :branch_code_format: "\\d{5}"
   :account_number_format: "\\d{7,12}"
@@ -1015,7 +1018,10 @@ NZ:
 US:
   :bank_code_length: 9
   :branch_code_length: 0
-  :account_number_length: 17
+  :account_number_length: !ruby/range
+    begin: 1
+    end: 17
+    excl: false
   :bank_code_format: "\\d{9}"
   :account_number_format: "_*\\d{1,17}"
   :national_id_length: 9

--- a/ibandit.gemspec
+++ b/ibandit.gemspec
@@ -5,8 +5,8 @@ require File.expand_path("lib/ibandit/version", __dir__)
 Gem::Specification.new do |gem|
   gem.add_development_dependency "gc_ruboconfig",   "~> 2.24.0"
   gem.add_development_dependency "nokogiri",        "~> 1.6"
-  gem.add_development_dependency "pry",             "~> 0.10"
-  gem.add_development_dependency "pry-nav",         "~> 0.2"
+  gem.add_development_dependency "pry",             "~> 0.13"
+  gem.add_development_dependency "pry-byebug",      "~> 3.9"
   gem.add_development_dependency "rspec",           "~> 3.3"
   gem.add_development_dependency "rspec-its",       "~> 1.2"
   gem.add_development_dependency "rspec_junit_formatter", "~> 0.4.1"

--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -174,9 +174,7 @@ module Ibandit
 
     def valid_branch_code_length?
       return unless valid_country_code?
-      if swift_branch_code.to_s.length == structure[:branch_code_length]
-        return true
-      end
+      return true if swift_branch_code.to_s.length == structure[:branch_code_length]
 
       if structure[:branch_code_length]&.zero?
         @errors[:branch_code] = Ibandit.translate(:not_used_in_country,
@@ -199,8 +197,13 @@ module Ibandit
         return false
       end
 
-      if swift_account_number.length == structure[:account_number_length]
-        return true
+      case structure[:account_number_length]
+      when Range
+        if structure[:account_number_length].include?(swift_account_number.length)
+          return true
+        end
+      else
+        return true if swift_account_number.length == structure[:account_number_length]
       end
 
       @errors[:account_number] =

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -91,7 +91,7 @@ module Ibandit
     def self.clean_ca_details(local_details)
       account_number = local_details[:account_number].tr("-", "")
 
-      return {} if account_number.length < 7 # minimum length
+      return {} unless (7..12).cover?(account_number.length)
 
       bank_code = if local_details[:bank_code].length == 3
                     local_details[:bank_code].rjust(4, "0")
@@ -100,7 +100,7 @@ module Ibandit
                   end
 
       {
-        account_number: account_number.rjust(12, "0"),
+        account_number: account_number,
         bank_code: bank_code,
       }
     end
@@ -113,7 +113,7 @@ module Ibandit
 
       {
         bank_code: local_details[:bank_code],
-        account_number: account_number.rjust(17, "_"),
+        account_number: account_number,
       }
     end
 
@@ -330,9 +330,7 @@ module Ibandit
     def self.clean_hu_details(local_details)
       # This method supports being passed the component IBAN parts, as defined
       # by SWIFT, or a single 16 or 24 digit string.
-      if local_details[:bank_code] || local_details[:branch_code]
-        return local_details
-      end
+      return local_details if local_details[:bank_code] || local_details[:branch_code]
 
       cleaned_acct_number = local_details[:account_number].gsub(/[-\s]/, "")
 

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ibandit
-  VERSION = "1.4.1"
+  VERSION = "1.5.0"
 end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -418,12 +418,12 @@ describe Ibandit::IBAN do
         its(:country_code) { is_expected.to eq("CA") }
         its(:bank_code) { is_expected.to eq("0036") }
         its(:branch_code) { is_expected.to eq("00063") }
-        its(:account_number) { is_expected.to eq("000000123456") }
+        its(:account_number) { is_expected.to eq("0123456") }
         its(:swift_bank_code) { is_expected.to eq("0036") }
         its(:swift_branch_code) { is_expected.to eq("00063") }
-        its(:swift_account_number) { is_expected.to eq("000000123456") }
+        its(:swift_account_number) { is_expected.to eq("0123456") }
         its(:swift_national_id) { is_expected.to eq("003600063") }
-        its(:pseudo_iban) { is_expected.to eq("CAZZ003600063000000123456") }
+        its(:pseudo_iban) { is_expected.to eq("CAZZ003600063_____0123456") }
 
         its(:iban) { is_expected.to be_nil }
         its(:valid?) { is_expected.to eq(true) }
@@ -437,12 +437,12 @@ describe Ibandit::IBAN do
         its(:country_code) { is_expected.to eq("CA") }
         its(:bank_code) { is_expected.to eq("36") }
         its(:branch_code) { is_expected.to eq("00063") }
-        its(:account_number) { is_expected.to eq("000000123456") }
+        its(:account_number) { is_expected.to eq("0123456") }
         its(:swift_bank_code) { is_expected.to eq("36") }
         its(:swift_branch_code) { is_expected.to eq("00063") }
-        its(:swift_account_number) { is_expected.to eq("000000123456") }
+        its(:swift_account_number) { is_expected.to eq("0123456") }
         its(:swift_national_id) { is_expected.to eq("3600063") }
-        its(:pseudo_iban) { is_expected.to eq("CAZZ__3600063000000123456") }
+        its(:pseudo_iban) { is_expected.to eq("CAZZ__3600063_____0123456") }
 
         its(:iban) { is_expected.to be_nil }
         its(:valid?) { is_expected.to eq(false) }
@@ -456,12 +456,12 @@ describe Ibandit::IBAN do
         its(:country_code) { is_expected.to eq("CA") }
         its(:bank_code) { is_expected.to eq("0036") }
         its(:branch_code) { is_expected.to eq("00063") }
-        its(:account_number) { is_expected.to eq("000000123456") }
+        its(:account_number) { is_expected.to eq("0123456") }
         its(:swift_bank_code) { is_expected.to eq("0036") }
         its(:swift_branch_code) { is_expected.to eq("00063") }
-        its(:swift_account_number) { is_expected.to eq("000000123456") }
+        its(:swift_account_number) { is_expected.to eq("0123456") }
         its(:swift_national_id) { is_expected.to eq("003600063") }
-        its(:pseudo_iban) { is_expected.to eq("CAZZ003600063000000123456") }
+        its(:pseudo_iban) { is_expected.to eq("CAZZ003600063_____0123456") }
 
         its(:iban) { is_expected.to be_nil }
         its(:valid?) { is_expected.to eq(true) }
@@ -501,11 +501,11 @@ describe Ibandit::IBAN do
       its(:country_code) { is_expected.to eq("CA") }
       its(:bank_code) { is_expected.to eq("0036") }
       its(:branch_code) { is_expected.to eq("00063") }
-      its(:account_number) { is_expected.to eq("000000123456") }
+      its(:account_number) { is_expected.to eq("0123456") }
       its(:swift_bank_code) { is_expected.to eq("0036") }
       its(:swift_branch_code) { is_expected.to eq("00063") }
-      its(:swift_account_number) { is_expected.to eq("000000123456") }
-      its(:pseudo_iban) { is_expected.to eq("CAZZ003600063000000123456") }
+      its(:swift_account_number) { is_expected.to eq("0123456") }
+      its(:pseudo_iban) { is_expected.to eq("CAZZ003600063_____0123456") }
 
       its(:iban) { is_expected.to be_nil }
       its(:valid?) { is_expected.to be true }
@@ -518,7 +518,7 @@ describe Ibandit::IBAN do
       it "is invalid and has the correct errors" do
         expect(subject.valid?).to eq(false)
         expect(subject.errors).
-          to eq(account_number: "is the wrong length (should be 12 characters)")
+          to eq(account_number: "is the wrong length (should be 7..12 characters)")
       end
     end
 
@@ -709,10 +709,10 @@ describe Ibandit::IBAN do
 
         its(:country_code) { is_expected.to eq("US") }
         its(:bank_code) { is_expected.to eq(bank_code) }
-        its(:account_number) { is_expected.to eq("__________0123456") }
+        its(:account_number) { is_expected.to eq("0123456") }
         its(:swift_bank_code) { is_expected.to eq(bank_code) }
         its(:swift_branch_code) { is_expected.to eq(nil) }
-        its(:swift_account_number) { is_expected.to eq("__________0123456") }
+        its(:swift_account_number) { is_expected.to eq("0123456") }
         its(:swift_national_id) { is_expected.to eq(bank_code) }
 
         its(:pseudo_iban) do

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -163,7 +163,7 @@ describe Ibandit::LocalDetailsCleaner do
     let(:bank_code) { "0036" }
     let(:branch_code) { "00063" }
 
-    its([:account_number]) { is_expected.to eq("000000123456") }
+    its([:account_number]) { is_expected.to eq("0123456") }
     its([:country_code]) { is_expected.to eq(country_code) }
     its([:bank_code]) { is_expected.to eq("0036") }
     its([:branch_code]) { is_expected.to eq("00063") }
@@ -171,7 +171,7 @@ describe Ibandit::LocalDetailsCleaner do
     context "with a hyphen" do
       let(:account_number) { "0123456-789" }
 
-      its([:account_number]) { is_expected.to eq("000123456789") }
+      its([:account_number]) { is_expected.to eq("0123456789") }
     end
   end
 
@@ -1311,7 +1311,7 @@ describe Ibandit::LocalDetailsCleaner do
       let(:account_number) { "0123456789" }
 
       its([:bank_code]) { is_expected.to eq(bank_code) }
-      its([:account_number]) { is_expected.to eq("_______0123456789") }
+      its([:account_number]) { is_expected.to eq("0123456789") }
     end
   end
 end


### PR DESCRIPTION
We've noticed that we've been seeing some issues with account numbers in PAD; we're padding out too many digits.

This change 
- Adds padding with `_` rather than 0s for bank details within the range of account numbers with 7 to 12 digits - removed by the splitter
- Adds range support for validating account number length
- Fixes `_` from appearing in `iban.account_number`