### PR TITLE
Stop padding Australian account numbers with 0s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0 - Sept 8, 2021
+
+- Stop padding out Australian account details to 10 digits
+
 ## 1.6.1 - Aug 13, 2021
 
 - Update BLZ data - BLZ_20210906

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -983,9 +983,12 @@ EG:
 AU:
   :bank_code_length: 0
   :branch_code_length: 6
-  :account_number_length: 10
+  :account_number_length: !ruby/range
+    begin: 5
+    end: 10
+    excl: false
   :branch_code_format: "\\d{6}"
-  :account_number_format: "[A-Z0-9]{10}"
+  :account_number_format: "[A-Z0-9]{5,10}"
   :pseudo_iban_bank_code_length: 0
   :pseudo_iban_branch_code_length: 6
   :pseudo_iban_account_number_length: 10

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -68,14 +68,13 @@ module Ibandit
 
     def self.clean_au_details(local_details)
       # Account number may be up to 10 digits long.
-      # Add leading zeros to account number if < 10 digits.
       #
       # Minimum account_number length is 5
       return {} unless local_details[:account_number].length >= 5
 
       {
         branch_code: local_details[:branch_code].delete("-"),
-        account_number: local_details[:account_number].rjust(10, "0"),
+        account_number: local_details[:account_number],
       }
     end
 

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ibandit
-  VERSION = "1.6.1"
+  VERSION = "1.7.0"
 end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -201,13 +201,13 @@ describe Ibandit::IBAN do
         its(:country_code) { is_expected.to eq("AU") }
         its(:bank_code) { is_expected.to be_nil }
         its(:branch_code) { is_expected.to eq("123456") }
-        its(:account_number) { is_expected.to eq("0123456789") }
+        its(:account_number) { is_expected.to eq("123456789") }
         its(:swift_bank_code) { is_expected.to be_nil }
         its(:swift_branch_code) { is_expected.to eq("123456") }
-        its(:swift_account_number) { is_expected.to eq("0123456789") }
+        its(:swift_account_number) { is_expected.to eq("123456789") }
         its(:swift_national_id) { is_expected.to eq("123456") }
         its(:iban) { is_expected.to be_nil }
-        its(:pseudo_iban) { is_expected.to eq("AUZZ1234560123456789") }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ123456_123456789") }
         its(:valid?) { is_expected.to eq(true) }
         its(:to_s) { is_expected.to eq("") }
       end
@@ -218,13 +218,13 @@ describe Ibandit::IBAN do
         its(:country_code) { is_expected.to eq("AU") }
         its(:bank_code) { is_expected.to be_nil }
         its(:branch_code) { is_expected.to eq("123456") }
-        its(:account_number) { is_expected.to eq("0000012345") }
+        its(:account_number) { is_expected.to eq("12345") }
         its(:swift_bank_code) { is_expected.to be_nil }
         its(:swift_branch_code) { is_expected.to eq("123456") }
-        its(:swift_account_number) { is_expected.to eq("0000012345") }
+        its(:swift_account_number) { is_expected.to eq("12345") }
         its(:swift_national_id) { is_expected.to eq("123456") }
         its(:iban) { is_expected.to be_nil }
-        its(:pseudo_iban) { is_expected.to eq("AUZZ1234560000012345") }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ123456_____12345") }
         its(:valid?) { is_expected.to eq(true) }
         its(:to_s) { is_expected.to eq("") }
       end
@@ -235,13 +235,13 @@ describe Ibandit::IBAN do
         its(:country_code) { is_expected.to eq("AU") }
         its(:bank_code) { is_expected.to be_nil }
         its(:branch_code) { is_expected.to eq("123456") }
-        its(:account_number) { is_expected.to eq("0000123456") }
+        its(:account_number) { is_expected.to eq("123456") }
         its(:swift_bank_code) { is_expected.to be_nil }
         its(:swift_branch_code) { is_expected.to eq("123456") }
-        its(:swift_account_number) { is_expected.to eq("0000123456") }
+        its(:swift_account_number) { is_expected.to eq("123456") }
         its(:swift_national_id) { is_expected.to eq("123456") }
         its(:iban) { is_expected.to be_nil }
-        its(:pseudo_iban) { is_expected.to eq("AUZZ1234560000123456") }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ123456____123456") }
         its(:valid?) { is_expected.to eq(true) }
         its(:to_s) { is_expected.to eq("") }
       end
@@ -269,13 +269,13 @@ describe Ibandit::IBAN do
         its(:country_code) { is_expected.to eq("AU") }
         its(:bank_code) { is_expected.to be_nil }
         its(:branch_code) { is_expected.to eq("123456") }
-        its(:account_number) { is_expected.to eq("0XX1234567") }
+        its(:account_number) { is_expected.to eq("XX1234567") }
         its(:swift_bank_code) { is_expected.to be_nil }
         its(:swift_branch_code) { is_expected.to eq("123456") }
-        its(:swift_account_number) { is_expected.to eq("0XX1234567") }
+        its(:swift_account_number) { is_expected.to eq("XX1234567") }
         its(:swift_national_id) { is_expected.to eq("123456") }
         its(:iban) { is_expected.to be_nil }
-        its(:pseudo_iban) { is_expected.to eq("AUZZ1234560XX1234567") }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ123456_XX1234567") }
         its(:valid?) { is_expected.to eq(true) }
         its(:to_s) { is_expected.to eq("") }
       end
@@ -303,13 +303,13 @@ describe Ibandit::IBAN do
         its(:country_code) { is_expected.to eq("AU") }
         its(:bank_code) { is_expected.to be_nil }
         its(:branch_code) { is_expected.to eq("123456") }
-        its(:account_number) { is_expected.to eq("0000000000") }
+        its(:account_number) { is_expected.to eq("000000") }
         its(:swift_bank_code) { is_expected.to be_nil }
         its(:swift_branch_code) { is_expected.to eq("123456") }
-        its(:swift_account_number) { is_expected.to eq("0000000000") }
+        its(:swift_account_number) { is_expected.to eq("000000") }
         its(:swift_national_id) { is_expected.to eq("123456") }
         its(:iban) { is_expected.to be_nil }
-        its(:pseudo_iban) { is_expected.to eq("AUZZ1234560000000000") }
+        its(:pseudo_iban) { is_expected.to eq("AUZZ123456____000000") }
         its(:valid?) { is_expected.to eq(false) }
         its(:to_s) { is_expected.to eq("") }
       end
@@ -321,13 +321,13 @@ describe Ibandit::IBAN do
       its(:country_code) { is_expected.to eq("AU") }
       its(:bank_code) { is_expected.to be_nil }
       its(:branch_code) { is_expected.to eq("123456") }
-      its(:account_number) { is_expected.to eq("0123456789") }
+      its(:account_number) { is_expected.to eq("123456789") }
       its(:swift_bank_code) { is_expected.to be_nil }
       its(:swift_branch_code) { is_expected.to eq("123456") }
-      its(:swift_account_number) { is_expected.to eq("0123456789") }
+      its(:swift_account_number) { is_expected.to eq("123456789") }
       its(:swift_national_id) { is_expected.to eq("123456") }
       its(:iban) { is_expected.to be_nil }
-      its(:pseudo_iban) { is_expected.to eq("AUZZ1234560123456789") }
+      its(:pseudo_iban) { is_expected.to eq("AUZZ123456_123456789") }
       its(:valid?) { is_expected.to eq(true) }
       its(:to_s) { is_expected.to eq("") }
 
@@ -358,7 +358,7 @@ describe Ibandit::IBAN do
       it "is invalid and has the correct errors" do
         expect(subject.valid?).to eq(false)
         expect(subject.errors).
-          to eq(account_number: "is the wrong length (should be 10 characters)")
+          to eq(account_number: "is the wrong length (should be 5..10 characters)")
       end
     end
 
@@ -377,7 +377,7 @@ describe Ibandit::IBAN do
       it "is invalid and has the correct errors" do
         expect(subject.valid?).to eq(false)
         expect(subject.errors).to eq(
-          account_number: "is the wrong length (should be 10 characters)",
+          account_number: "is the wrong length (should be 5..10 characters)",
         )
       end
     end

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -95,7 +95,7 @@ describe Ibandit::LocalDetailsCleaner do
       let(:branch_code) { "123-456" }
 
       its([:country_code]) { is_expected.to eq(country_code) }
-      its([:account_number]) { is_expected.to eq("0123456789") }
+      its([:account_number]) { is_expected.to eq("123456789") }
       its([:branch_code]) { is_expected.to eq("123456") }
     end
 
@@ -103,7 +103,7 @@ describe Ibandit::LocalDetailsCleaner do
       let(:branch_code) { "123456" }
 
       its([:country_code]) { is_expected.to eq(country_code) }
-      its([:account_number]) { is_expected.to eq("0123456789") }
+      its([:account_number]) { is_expected.to eq("123456789") }
       its([:branch_code]) { is_expected.to eq("123456") }
     end
   end


### PR DESCRIPTION
Not sure why this was implemented in the first place but Australian account numbers can be 5..10 digits long and shouldnt be padded with 0s﻿
