### PR TITLE
Fix gem loading error

### DIFF
--- a/bin/build_structure_file.rb
+++ b/bin/build_structure_file.rb
@@ -154,7 +154,7 @@ if __FILE__ == $PROGRAM_NAME
   )
 
   structure_additions = YAML.safe_load(
-    Pathname.new(__dir__).join("../data/raw/structure_additions.yml").read,
+    File.read(File.expand_path("../data/raw/structure_additions.yml", __dir__)),
     permitted_classes: [Range, Symbol],
   )
 

--- a/lib/ibandit.rb
+++ b/lib/ibandit.rb
@@ -31,7 +31,7 @@ module Ibandit
 
     def structures
       @structures ||= YAML.safe_load(
-        Pathname.new(__dir__).join("../data/structures.yml").read,
+        File.read(File.expand_path("../data/structures.yml", __dir__)),
         permitted_classes: [Range, Symbol],
       )
     end

--- a/spec/ibandit/structure_spec.rb
+++ b/spec/ibandit/structure_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "structures.yml" do
-  structure_file = Pathname.new(__dir__).join("../../data/structures.yml").read
+  structure_file = File.read(File.expand_path("../../data/structures.yml", __dir__))
   structures = YAML.safe_load(structure_file, permitted_classes: [Range, Symbol])
 
   structures.each do |country, rules|


### PR DESCRIPTION
Fixes load errors, because `require 'pathname'` is missing.
This removes the need to use Pathname
```
$ irb
> require 'ibandit'
> Ibandit::IBAN.new('BE71096123456769').to_s

1: from gems/ibandit-1.8.0/lib/ibandit.rb:34:in `structures'
NameError (uninitialized constant #<Class:Ibandit>::Pathname)
```