### PR TITLE
Update minimum US account number

### DIFF
--- a/data/raw/pseudo_ibans.yml
+++ b/data/raw/pseudo_ibans.yml
@@ -41,11 +41,11 @@ US:
   :bank_code_length: 9
   :branch_code_length: 0
   :account_number_length: !ruby/range
-    begin: 1
+    begin: 4
     end: 17
     excl: false
   :bank_code_format: "\\d{9}"
-  :account_number_format: "_*\\d{1,17}"
+  :account_number_format: "_*\\d{4,17}"
   :national_id_length: 9
   :pseudo_iban_bank_code_length: 9
   :pseudo_iban_branch_code_length: 0

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -1521,11 +1521,11 @@ US:
   :bank_code_length: 9
   :branch_code_length: 0
   :account_number_length: !ruby/range
-    begin: 1
+    begin: 4
     end: 17
     excl: false
   :bank_code_format: "\\d{9}"
-  :account_number_format: _*\d{1,17}
+  :account_number_format: _*\d{4,17}
   :national_id_length: 9
   :pseudo_iban_bank_code_length: 9
   :pseudo_iban_branch_code_length: 0

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ibandit
-  VERSION = "1.15.0"
+  VERSION = "1.16.0"
 end


### PR DESCRIPTION
PR changes:
- Make sure account number is at least 4 digits for US.

**Further discussion:**
What is the actual minimum for a US account number?