### PR TITLE
CA update

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,16 +526,16 @@ iban = Ibandit::IBAN.new(
   country_code: 'CA',
   bank_code: '0036',          # 3 or 4 digit Financial Institution number
   branch_code: '00063',       # 5 digit Branch Transit number
-  account_number: '0123456'   # 7 to 12 digits
+  account_number: '123456'    # 1 to 12 digits
 )
-iban.pseudo_iban              # => "CAZZ003600063000000123456"
+iban.pseudo_iban              # => "CAZZ003600063______123456"
 iban.iban                     # => nil
 
-iban = Ibandit::IBAN.new('CAZZ003600063000000123456')
+iban = Ibandit::IBAN.new('CAZZ003600063______123456')
 iban.country_code             # => "CA"
 iban.bank_code                # => "0036"
 iban.branch_code              # => "00063"
-iban.account_number           # => "000000123456"
+iban.account_number           # => "123456"
 iban.iban                     # => nil
 
 # New Zealand

--- a/data/raw/pseudo_ibans.yml
+++ b/data/raw/pseudo_ibans.yml
@@ -16,12 +16,12 @@ CA:
   :bank_code_length: 4
   :branch_code_length: 5
   :account_number_length: !ruby/range
-    begin: 7
+    begin: 1
     end: 12
     excl: false
   :bank_code_format: "\\d{4}"
   :branch_code_format: "\\d{5}"
-  :account_number_format: "\\d{7,12}"
+  :account_number_format: "[1-9]\\d{0,11}" # 1-12 digits, 0 not allowed
   :national_id_length: 9
   :pseudo_iban_bank_code_length: 4
   :pseudo_iban_branch_code_length: 5

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -1496,12 +1496,12 @@ CA:
   :bank_code_length: 4
   :branch_code_length: 5
   :account_number_length: !ruby/range
-    begin: 7
+    begin: 1
     end: 12
     excl: false
   :bank_code_format: "\\d{4}"
   :branch_code_format: "\\d{5}"
-  :account_number_format: "\\d{7,12}"
+  :account_number_format: "[1-9]\\d{0,11}"
   :national_id_length: 9
   :pseudo_iban_bank_code_length: 4
   :pseudo_iban_branch_code_length: 5

--- a/lib/ibandit/local_details_cleaner.rb
+++ b/lib/ibandit/local_details_cleaner.rb
@@ -91,7 +91,10 @@ module Ibandit
     def self.clean_ca_details(local_details)
       account_number = local_details[:account_number].tr("-", "")
 
-      return {} unless (7..12).cover?(account_number.length)
+      if account_number =~ /\A\d+\z/
+        account_number = account_number.gsub(/\A0+/, "")
+        account_number = "0" if account_number.length == 0
+      end
 
       bank_code = if local_details[:bank_code].length == 3
                     local_details[:bank_code].rjust(4, "0")

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -428,18 +428,18 @@ describe Ibandit::IBAN do
       end
 
       context "and a 3 digit bank code" do
-        let(:account_number) { "0123456" }
+        let(:account_number) { "12345678" }
         let(:bank_code) { "036" }
 
         its(:country_code) { is_expected.to eq("CA") }
         its(:bank_code) { is_expected.to eq("0036") }
         its(:branch_code) { is_expected.to eq("00063") }
-        its(:account_number) { is_expected.to eq("0123456") }
+        its(:account_number) { is_expected.to eq("12345678") }
         its(:swift_bank_code) { is_expected.to eq("0036") }
         its(:swift_branch_code) { is_expected.to eq("00063") }
-        its(:swift_account_number) { is_expected.to eq("0123456") }
+        its(:swift_account_number) { is_expected.to eq("12345678") }
         its(:swift_national_id) { is_expected.to eq("003600063") }
-        its(:pseudo_iban) { is_expected.to eq("CAZZ003600063_____0123456") }
+        its(:pseudo_iban) { is_expected.to eq("CAZZ003600063____12345678") }
 
         its(:iban) { is_expected.to be_nil }
         its(:valid?) { is_expected.to eq(true) }
@@ -447,40 +447,21 @@ describe Ibandit::IBAN do
       end
 
       context "and a 2 digit bank code" do
-        let(:account_number) { "0123456" }
+        let(:account_number) { "12345678" }
         let(:bank_code) { "36" }
 
         its(:country_code) { is_expected.to eq("CA") }
         its(:bank_code) { is_expected.to eq("36") }
         its(:branch_code) { is_expected.to eq("00063") }
-        its(:account_number) { is_expected.to eq("0123456") }
+        its(:account_number) { is_expected.to eq("12345678") }
         its(:swift_bank_code) { is_expected.to eq("36") }
         its(:swift_branch_code) { is_expected.to eq("00063") }
-        its(:swift_account_number) { is_expected.to eq("0123456") }
+        its(:swift_account_number) { is_expected.to eq("12345678") }
         its(:swift_national_id) { is_expected.to eq("3600063") }
-        its(:pseudo_iban) { is_expected.to eq("CAZZ__3600063_____0123456") }
+        its(:pseudo_iban) { is_expected.to eq("CAZZ__3600063____12345678") }
 
         its(:iban) { is_expected.to be_nil }
         its(:valid?) { is_expected.to eq(false) }
-        its(:to_s) { is_expected.to eq("") }
-      end
-
-      context "and a 7 digit account number" do
-        let(:account_number) { "0123456" }
-        let(:bank_code) { "0036" }
-
-        its(:country_code) { is_expected.to eq("CA") }
-        its(:bank_code) { is_expected.to eq("0036") }
-        its(:branch_code) { is_expected.to eq("00063") }
-        its(:account_number) { is_expected.to eq("0123456") }
-        its(:swift_bank_code) { is_expected.to eq("0036") }
-        its(:swift_branch_code) { is_expected.to eq("00063") }
-        its(:swift_account_number) { is_expected.to eq("0123456") }
-        its(:swift_national_id) { is_expected.to eq("003600063") }
-        its(:pseudo_iban) { is_expected.to eq("CAZZ003600063_____0123456") }
-
-        its(:iban) { is_expected.to be_nil }
-        its(:valid?) { is_expected.to eq(true) }
         its(:to_s) { is_expected.to eq("") }
       end
 
@@ -491,50 +472,164 @@ describe Ibandit::IBAN do
         its(:valid?) { is_expected.to be false }
       end
 
-      context "and a 12 digit account number" do
-        let(:account_number) { "012345678900" }
+      context "and account number is too long" do
+        let(:account_number) { "1234567890123" }
         let(:bank_code) { "0036" }
 
-        its(:country_code) { is_expected.to eq("CA") }
-        its(:bank_code) { is_expected.to eq("0036") }
-        its(:branch_code) { is_expected.to eq("00063") }
-        its(:account_number) { is_expected.to eq("012345678900") }
-        its(:swift_bank_code) { is_expected.to eq("0036") }
-        its(:swift_branch_code) { is_expected.to eq("00063") }
-        its(:swift_account_number) { is_expected.to eq("012345678900") }
-        its(:swift_national_id) { is_expected.to eq("003600063") }
-        its(:pseudo_iban) { is_expected.to eq("CAZZ003600063012345678900") }
+        it "is invalid and has the correct errors" do
+          expect(subject.valid?).to eq(false)
+          expect(subject.errors).
+            to eq(account_number: "is the wrong length (should be 1..12 characters)")
+        end
+      end
 
-        its(:iban) { is_expected.to be_nil }
-        its(:valid?) { is_expected.to be true }
-        its(:to_s) { is_expected.to eq("") }
+      context "and a 7 digit account number" do
+        let(:bank_code) { "0036" }
+
+        shared_examples "seven_digit_shared_examples" do
+          its(:country_code) { is_expected.to eq("CA") }
+          its(:bank_code) { is_expected.to eq("0036") }
+          its(:branch_code) { is_expected.to eq("00063") }
+          its(:swift_bank_code) { is_expected.to eq("0036") }
+          its(:swift_branch_code) { is_expected.to eq("00063") }
+          its(:swift_national_id) { is_expected.to eq("003600063") }
+
+          its(:iban) { is_expected.to be_nil }
+          its(:to_s) { is_expected.to eq("") }
+        end
+
+        context "with no leading zeroes" do
+          let(:account_number) { "1234567" }
+
+          include_examples "seven_digit_shared_examples"
+          its(:valid?) { is_expected.to eq(true) }
+          its(:account_number) { is_expected.to eq("1234567") }
+          its(:swift_account_number) { is_expected.to eq("1234567") }
+          its(:pseudo_iban) { is_expected.to eq("CAZZ003600063_____1234567") }
+        end
+
+        context "with some leading zeroes" do
+          let(:account_number) { "0123456" }
+
+          include_examples "seven_digit_shared_examples"
+          its(:account_number) { is_expected.to eq("123456") }
+          its(:swift_account_number) { is_expected.to eq("123456") }
+          its(:pseudo_iban) { is_expected.to eq("CAZZ003600063______123456") }
+          its(:valid?) { is_expected.to eq(true) }
+        end
+
+        context "with lots of leading zeroes" do
+          let(:account_number) { "0000001" }
+
+          include_examples "seven_digit_shared_examples"
+          its(:account_number) { is_expected.to eq("1") }
+          its(:swift_account_number) { is_expected.to eq("1") }
+          its(:pseudo_iban) { is_expected.to eq("CAZZ003600063___________1") }
+          its(:valid?) { is_expected.to eq(true) }
+        end
+
+        context "with all zeroes" do
+          let(:account_number) { "0000000" }
+
+          include_examples "seven_digit_shared_examples"
+          its(:account_number) { is_expected.to eq("0") }
+          its(:swift_account_number) { is_expected.to eq("0") }
+          its(:pseudo_iban) { is_expected.to eq("CAZZ003600063___________0") }
+          its(:valid?) { is_expected.to eq(false) }
+        end
+      end
+
+      context "and a 12 digit account number" do
+        let(:bank_code) { "0036" }
+
+        shared_examples "twelve_digit_shared_examples" do
+          its(:country_code) { is_expected.to eq("CA") }
+          its(:bank_code) { is_expected.to eq("0036") }
+          its(:branch_code) { is_expected.to eq("00063") }
+          its(:swift_bank_code) { is_expected.to eq("0036") }
+          its(:swift_branch_code) { is_expected.to eq("00063") }
+          its(:swift_national_id) { is_expected.to eq("003600063") }
+
+          its(:iban) { is_expected.to be_nil }
+          its(:to_s) { is_expected.to eq("") }
+        end
+
+        context "with no leading zeroes" do
+          let(:account_number) { "123456789012" }
+
+          include_examples "twelve_digit_shared_examples"
+          its(:account_number) { is_expected.to eq("123456789012") }
+          its(:swift_account_number) { is_expected.to eq("123456789012") }
+          its(:pseudo_iban) { is_expected.to eq("CAZZ003600063123456789012") }
+          its(:valid?) { is_expected.to be true }
+        end
+
+        context "with some leading zeroes" do
+          let(:account_number) { "012345678900" }
+
+          include_examples "twelve_digit_shared_examples"
+          its(:account_number) { is_expected.to eq("12345678900") }
+          its(:swift_account_number) { is_expected.to eq("12345678900") }
+          its(:pseudo_iban) { is_expected.to eq("CAZZ003600063_12345678900") }
+          its(:valid?) { is_expected.to be true }
+        end
+
+        context "with lots of leading zeroes" do
+          let(:account_number) { "000000000001" }
+
+          include_examples "twelve_digit_shared_examples"
+          its(:account_number) { is_expected.to eq("1") }
+          its(:swift_account_number) { is_expected.to eq("1") }
+          its(:pseudo_iban) { is_expected.to eq("CAZZ003600063___________1") }
+          its(:valid?) { is_expected.to be true }
+        end
+
+        context "with all zeroes" do
+          let(:account_number) { "000000000000" }
+
+          include_examples "twelve_digit_shared_examples"
+          its(:account_number) { is_expected.to eq("0") }
+          its(:swift_account_number) { is_expected.to eq("0") }
+          its(:pseudo_iban) { is_expected.to eq("CAZZ003600063___________0") }
+          its(:valid?) { is_expected.to be false }
+        end
       end
     end
 
     context "when the IBAN was created from an Canadian pseudo-IBAN" do
-      let(:arg) { "CAZZ0036000630123456" }
+      let(:arg) { "CAZZ003600063_123456" }
 
       its(:country_code) { is_expected.to eq("CA") }
       its(:bank_code) { is_expected.to eq("0036") }
       its(:branch_code) { is_expected.to eq("00063") }
-      its(:account_number) { is_expected.to eq("0123456") }
+      its(:account_number) { is_expected.to eq("123456") }
       its(:swift_bank_code) { is_expected.to eq("0036") }
       its(:swift_branch_code) { is_expected.to eq("00063") }
-      its(:swift_account_number) { is_expected.to eq("0123456") }
-      its(:pseudo_iban) { is_expected.to eq("CAZZ003600063_____0123456") }
+      its(:swift_account_number) { is_expected.to eq("123456") }
+      its(:pseudo_iban) { is_expected.to eq("CAZZ003600063______123456") }
 
       its(:iban) { is_expected.to be_nil }
       its(:valid?) { is_expected.to be true }
       its(:to_s) { is_expected.to eq("") }
     end
 
-    context "when the input is an invalid Canadian pseudo-IBAN" do
-      let(:arg) { "CAZZ00360006301234" }
+    context "when the input is an invalid (all-zeroes account number) Canadian pseudo-IBAN" do
+      let(:arg) { "CAZZ003600063000" }
 
       it "is invalid and has the correct errors" do
         expect(subject.valid?).to eq(false)
         expect(subject.errors).
-          to eq(account_number: "is the wrong length (should be 7..12 characters)")
+          to eq(account_number: "format is invalid")
+      end
+    end
+
+    context "when the input is an invalid (blank account number) Canadian pseudo-IBAN" do
+      let(:arg) { "CAZZ003600063" }
+
+      it "is invalid and has the correct errors" do
+        expect(subject.valid?).to eq(false)
+        expect(subject.errors).
+          to eq(account_number: "is the wrong length (should be 1..12 characters)")
       end
     end
 

--- a/spec/ibandit/local_details_cleaner_spec.rb
+++ b/spec/ibandit/local_details_cleaner_spec.rb
@@ -159,19 +159,48 @@ describe Ibandit::LocalDetailsCleaner do
 
   context "Canada" do
     let(:country_code) { "CA" }
-    let(:account_number) { "0123456" }
+    let(:account_number) { "1234567" }
     let(:bank_code) { "0036" }
     let(:branch_code) { "00063" }
 
-    its([:account_number]) { is_expected.to eq("0123456") }
+    its([:account_number]) { is_expected.to eq("1234567") }
     its([:country_code]) { is_expected.to eq(country_code) }
     its([:bank_code]) { is_expected.to eq("0036") }
     its([:branch_code]) { is_expected.to eq("00063") }
 
     context "with a hyphen" do
-      let(:account_number) { "0123456-789" }
+      let(:account_number) { "123456-789" }
 
-      its([:account_number]) { is_expected.to eq("0123456789") }
+      its([:account_number]) { is_expected.to eq("123456789") }
+
+      context "with leading zeroes" do
+        let(:account_number) { "0123456-789" }
+        its([:account_number]) { is_expected.to eq("123456789") }
+      end
+    end
+
+    context "only zeroes" do
+      let(:account_number) { "00000" }
+
+      its([:account_number]) { is_expected.to eq("0") }
+    end
+
+    context "with leading zeroes" do
+      let(:account_number) { "0000001" }
+
+      its([:account_number]) { is_expected.to eq("1") }
+    end
+
+    context "number without leading zeroes" do
+      let(:account_number) { "12345" }
+
+      its([:account_number]) { is_expected.to eq("12345") }
+    end
+
+    context "with invalid characters" do
+      let(:account_number) { "00x123" }
+
+      its([:account_number]) { is_expected.to eq("00x123") }
     end
   end
 

--- a/spec/ibandit/pseudo_iban_splitter_spec.rb
+++ b/spec/ibandit/pseudo_iban_splitter_spec.rb
@@ -98,6 +98,15 @@ describe Ibandit::PseudoIBANSplitter do
       its([:account_number]) { is_expected.to eq("012345678900") }
     end
 
+    context "for a canadian pseudo-IBAN with a all-zeroes account number" do
+      let(:pseudo_iban) { "CAZZ003600063000000000000" }
+
+      its([:country_code]) { is_expected.to eq("CA") }
+      its([:bank_code]) { is_expected.to eq("0036") }
+      its([:branch_code]) { is_expected.to eq("00063") }
+      its([:account_number]) { is_expected.to eq("000000000000") }
+    end
+
     context "for a US pseudo-IBAN without padding" do
       let(:pseudo_iban) { "USZZ0123456780123456" }
 


### PR DESCRIPTION
allow variable length (up to 12) numbers as CA account numbers; remove 0 padding if present; do not allow CA account number 0 (single zero)