### PR TITLE
Do not allow all-0 account numbers for CA; refactor all-0 check for AU

### DIFF
--- a/data/raw/pseudo_ibans.yml
+++ b/data/raw/pseudo_ibans.yml
@@ -7,7 +7,7 @@ AU:
     end: 10
     excl: false
   :branch_code_format: "\\d{6}"
-  :account_number_format: "[A-Z0-9]{5,10}"
+  :account_number_format: "(?!0+\\z)[A-Z0-9]{5,10}"
   :pseudo_iban_bank_code_length: 0
   :pseudo_iban_branch_code_length: 6
   :pseudo_iban_account_number_length: 10
@@ -21,7 +21,7 @@ CA:
     excl: false
   :bank_code_format: "\\d{4}"
   :branch_code_format: "\\d{5}"
-  :account_number_format: "\\d{7,12}"
+  :account_number_format: "(?!0+\\z)\\d{7,12}"
   :national_id_length: 9
   :pseudo_iban_bank_code_length: 4
   :pseudo_iban_branch_code_length: 5

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -1487,7 +1487,7 @@ AU:
     end: 10
     excl: false
   :branch_code_format: "\\d{6}"
-  :account_number_format: "[A-Z0-9]{5,10}"
+  :account_number_format: "(?!0+\\z)[A-Z0-9]{5,10}"
   :pseudo_iban_bank_code_length: 0
   :pseudo_iban_branch_code_length: 6
   :pseudo_iban_account_number_length: 10
@@ -1501,7 +1501,7 @@ CA:
     excl: false
   :bank_code_format: "\\d{4}"
   :branch_code_format: "\\d{5}"
-  :account_number_format: "\\d{7,12}"
+  :account_number_format: "(?!0+\\z)\\d{7,12}"
   :national_id_length: 9
   :pseudo_iban_bank_code_length: 4
   :pseudo_iban_branch_code_length: 5

--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -386,12 +386,6 @@ module Ibandit
 
     def valid_australian_details?
       return true unless country_code == "AU"
-
-      bsb_check? && account_number_not_all_zeros?
-    end
-
-    def bsb_check?
-      return true unless country_code == "AU"
       return true unless Ibandit.modulus_checker
 
       valid_modulus_check_branch_code?
@@ -549,13 +543,6 @@ module Ibandit
       return false if input.nil?
 
       input.slice(2, 2) == Constants::PSEUDO_IBAN_CHECK_DIGITS
-    end
-
-    def account_number_not_all_zeros?
-      return true if @swift_account_number.to_s.chars.uniq != ["0"]
-
-      @errors[:account_number] = Ibandit.translate(:is_invalid)
-      false
     end
   end
 end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -491,6 +491,17 @@ describe Ibandit::IBAN do
         its(:valid?) { is_expected.to be false }
       end
 
+      context "and account number has only zeroes in it" do
+        let(:account_number) { "0000000" }
+        let(:bank_code) { "0036" }
+
+        it "is invalid and has the correct errors" do
+          expect(subject.valid?).to eq(false)
+          expect(subject.errors).
+            to eq(account_number: "format is invalid")
+        end
+      end
+
       context "and a 12 digit account number" do
         let(:account_number) { "012345678900" }
         let(:bank_code) { "0036" }


### PR DESCRIPTION
All-zero CA bank account numbers like 0000000 or 000000000000 should be treated as invalid.