### PR TITLE
[canada] - bank_code_length 4 -> 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.21.0 - August 6, 2024
+
+- Canada, Financial Institution number - allow 3 digits
+
 ## 1.20.0 - October 13, 2023
 
 - Do not allow all 0 transit numbers in CA

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.21.0 - August 6, 2024
 
 - Canada, Financial Institution number - allow 3 digits
+- modulus_checker failures will now return validation method specific error message
 
 ## 1.20.0 - October 13, 2023
 

--- a/data/raw/pseudo_ibans.yml
+++ b/data/raw/pseudo_ibans.yml
@@ -13,13 +13,16 @@ AU:
   :pseudo_iban_account_number_length: 10
   :national_id_length: 6
 CA:
-  :bank_code_length: 4
+  :bank_code_length: !ruby/range
+    begin: 3
+    end: 4
+    excl: false
   :branch_code_length: 5
   :account_number_length: !ruby/range
     begin: 7
     end: 12
     excl: false
-  :bank_code_format: "\\d{4}"
+  :bank_code_format: "\\d{3,4}"
   :branch_code_format: "0{0,4}[1-9][0-9]{0,4}"
   :account_number_format: "(?!0+\\z)\\d{7,12}"
   :national_id_length: 9

--- a/data/structures.yml
+++ b/data/structures.yml
@@ -1493,13 +1493,16 @@ AU:
   :pseudo_iban_account_number_length: 10
   :national_id_length: 6
 CA:
-  :bank_code_length: 4
+  :bank_code_length: !ruby/range
+    begin: 3
+    end: 4
+    excl: false
   :branch_code_length: 5
   :account_number_length: !ruby/range
     begin: 7
     end: 12
     excl: false
-  :bank_code_format: "\\d{4}"
+  :bank_code_format: "\\d{3,4}"
   :branch_code_format: 0{0,4}[1-9][0-9]{0,4}
   :account_number_format: "(?!0+\\z)\\d{7,12}"
   :national_id_length: 9

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ibandit
-  VERSION = "1.20.0"
+  VERSION = "1.21.0"
 end


### PR DESCRIPTION
The changes permit the input of CA details using a 3-digit bank code.

This should not affect the underlying systems, as the previous value is still accepted (4 digits). Additionally, the pseudo_iban_bank_code_length ensures that the returned value remains 4 digits long.

```ruby
iban1 = Ibandit::IBAN.new(country_code: 'CA', bank_code: '0036', branch_code: '00063', account_number: '0123456')
=> #<Ibandit::IBAN:0x0000000104c99f78
 @account_number="0123456",
 @bank_code="0036",
 @branch_code="00063",
 @country_code="CA",
 @errors={},
 @iban=nil,
 @source=:local_details,
 @swift_account_number="0123456",
 @swift_bank_code="0036",
 @swift_branch_code="00063">
 
iban2 = Ibandit::IBAN.new(country_code: 'CA', bank_code: '036', branch_code: '00063', account_number: '0123456')
=> #<Ibandit::IBAN:0x0000000104c978b8
 @account_number="0123456",
 @bank_code="0036",
 @branch_code="00063",
 @country_code="CA",
 @errors={},
 @iban=nil,
 @source=:local_details,
 @swift_account_number="0123456",
 @swift_bank_code="0036",
 @swift_branch_code="00063">
 
iban1.pseudo_iban == iban2.pseudo_iban
=> true

iban1.bank_code
=> "0036"

iban2.bank_code
=> "0036"
```