### PR TITLE
Clarify bank code and branch code errors

### DIFF
--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -17,3 +17,4 @@ da:
     bank_code_does_not_exist: "bankkoden findes ikke"
     has_invalid_clearing_code_length: "længden på clearingskoden er ugyldig"
     has_invalid_serial_number: "ugyldigt serienummer"
+    branch_code_does_not_exist: "filialkode findes ikke"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -17,3 +17,4 @@ de:
     bank_code_does_not_exist: "Bankleitzahl existiert nicht"
     has_invalid_clearing_code_length: "Länge des Verrechnungscodes ist ungültig"
     has_invalid_serial_number: "Seriennummer ist ungültig"
+    branch_code_does_not_exist: "Filialcode existiert nicht"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,3 +17,4 @@ en:
     bank_code_does_not_exist: "bank code does not exist"
     has_invalid_clearing_code_length: "clearing code length is invalid"
     has_invalid_serial_number: "serial number is invalid"
+    branch_code_does_not_exist: "branch code does not exist"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,7 +1,7 @@
 es:
   ibandit:
-    invalid_country_code: "\"%{country_code}\" no es un código de país IBAN ISO 3166-1 válido"
-    invalid_check_digits: "Los dígitos de verificación han generado un error en la comprobación del módulo. Se esperaba \"%{expected_check_digits}\", pero se ha recibido \"%{check_digits}\"."
+    invalid_country_code: '"%{country_code}" no es un código de país IBAN ISO 3166-1 válido'
+    invalid_check_digits: 'Los dígitos de verificación han generado un error en la comprobación del módulo. Se esperaba "%{expected_check_digits}", pero se ha recibido "%{check_digits}".'
     invalid_length: "La longitud no coincide con la especificación SWIFT (se esperaban %{expected_length} caracteres, pero se han recibido %{length})"
     is_required: "es obligatorio"
     wrong_length: "no tiene la longitud correcta (debe tener %{expected} caracteres)"
@@ -17,3 +17,4 @@ es:
     bank_code_does_not_exist: "codigo bancario inexistente"
     has_invalid_clearing_code_length: "codigo de oficina de oficina de compensación invalido"
     has_invalid_serial_number: "número de serie invalido"
+    branch_code_does_not_exist: "código de sucursal no existe"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -17,3 +17,4 @@ fr:
     bank_code_does_not_exist: "le code de la banque n'existe pas"
     has_invalid_clearing_code_length: "la longueur du clearing code n'est pas valide"
     has_invalid_serial_number: "le numéro de série n'est pas valide"
+    branch_code_does_not_exist: "le code de la succursale n'existe pas"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,6 +1,6 @@
 it:
   ibandit:
-    invalid_country_code: "\"%{country_code}\" non è un codice di paese IBAN 3166-1 valido"
+    invalid_country_code: '"%{country_code}" non è un codice di paese IBAN 3166-1 valido'
     invalid_check_digits: "Controllo del modulo non riuscito per i caratteri. %{expected_check_digits} caratteri previsti, %{check_digits} immessi."
     invalid_length: "La lunghezza non corrisponde alla specifica SWIFT (%{expected_length} caratteri previsti, %{length} immessi)"
     is_required: "è obbligatorio"
@@ -17,4 +17,4 @@ it:
     bank_code_does_not_exist: "codice banca inesistente"
     has_invalid_clearing_code_length: "lunghezza clearing code non valida"
     has_invalid_serial_number: "numero di serie non valido"
-
+    branch_code_does_not_exist: "codice filiale non esiste"

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -17,3 +17,4 @@ nb:
     bank_code_does_not_exist: "bankkoden eksisterer ikke"
     has_invalid_clearing_code_length: "registreringsnummerets lengde er ugyldig"
     has_invalid_serial_number: "ugyldig serienummer"
+    branch_code_does_not_exist: "filialkode eksisterer ikke"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -17,3 +17,4 @@ nl:
     bank_code_does_not_exist: "bankcode bestaat niet"
     has_invalid_clearing_code_length: "lengte clearingcode is ongeldig"
     has_invalid_serial_number: "serienummer is ongeldig"
+    branch_code_does_not_exist: "takcode bestaat niet"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -17,3 +17,4 @@ pt:
     bank_code_does_not_exist: "o código do banco não existe"
     has_invalid_clearing_code_length: "o comprimento do código de libertação é inválido"
     has_invalid_serial_number: "o número de série é inválido"
+    branch_code_does_not_exist: "código da filial não existe"

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -17,3 +17,4 @@ sl:
     bank_code_does_not_exist: "koda banke ne obstaja"
     has_invalid_clearing_code_length: "dolžina klirinške kode ni veljavna"
     has_invalid_serial_number: "serijska številka ni veljavna"
+    branch_code_does_not_exist: "koda podružnice ne obstaja"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -17,3 +17,4 @@ sv:
     bank_code_does_not_exist: "bankkoden existerar inte"
     has_invalid_clearing_code_length: "clearingnumrets längd är ogiltigt"
     has_invalid_serial_number: "ogiltigt serienummer"
+    branch_code_does_not_exist: "filialkod finns inte"

--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -512,14 +512,14 @@ module Ibandit
     def valid_modulus_check_bank_code?
       return true if Ibandit.modulus_checker.valid_bank_code?(self)
 
-      @errors[:bank_code] = Ibandit.translate(:failed_modulus_check)
+      @errors[:bank_code] = Ibandit.translate(:bank_code_does_not_exist)
       false
     end
 
     def valid_modulus_check_branch_code?
       return true if Ibandit.modulus_checker.valid_branch_code?(self)
 
-      @errors[:branch_code] = Ibandit.translate(:failed_modulus_check)
+      @errors[:branch_code] = Ibandit.translate(:branch_code_does_not_exist)
       false
     end
 

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -1341,7 +1341,7 @@ describe Ibandit::IBAN do
         it { is_expected.to be(false) }
 
         it "sets the errors on the IBAN" do
-          expect(iban.errors).to include(bank_code: "did not pass modulus check")
+          expect(iban.errors).to include(bank_code: "bank code does not exist")
         end
       end
 
@@ -1368,7 +1368,7 @@ describe Ibandit::IBAN do
         it { is_expected.to be(false) }
 
         it "sets the errors on the IBAN" do
-          expect(iban.errors).to include(branch_code: "did not pass modulus check")
+          expect(iban.errors).to include(branch_code: "branch code does not exist")
         end
       end
 
@@ -1581,7 +1581,7 @@ describe Ibandit::IBAN do
           it { is_expected.to be(false) }
 
           it "sets the errors on the IBAN" do
-            expect(iban.errors).to include(branch_code: "did not pass modulus check")
+            expect(iban.errors).to include(branch_code: "branch code does not exist")
           end
         end
       end
@@ -1646,7 +1646,7 @@ describe Ibandit::IBAN do
           it { is_expected.to be(false) }
 
           it "sets the errors on the IBAN" do
-            expect(iban.errors).to include(branch_code: "did not pass modulus check")
+            expect(iban.errors).to include(branch_code: "branch code does not exist")
           end
         end
       end
@@ -1711,7 +1711,7 @@ describe Ibandit::IBAN do
           it { is_expected.to be(false) }
 
           it "sets the errors on the IBAN" do
-            expect(iban.errors).to include(branch_code: "did not pass modulus check")
+            expect(iban.errors).to include(branch_code: "branch code does not exist")
           end
         end
       end


### PR DESCRIPTION
Currently these are returning `modulus_check` based errors when this is
not the case.

This PR updates the errors returned from branch and bank code checks to
be more representative.
