### PR TITLE
Always zerofill serial numbers when validating Swedish IBANs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.24.0 - February 18, 2025
+
+- Fix validation for SE IBANs where the account number starts with a 0 and the clearing number is not included in the IBAN
+
 ## 1.23.0 - February 14, 2025
 
 - Fix validation for SE IBANs for clearing code 3300 where the account number starts with a 0

--- a/data/raw/swedish_bank_lookup.yml
+++ b/data/raw/swedish_bank_lookup.yml
@@ -85,7 +85,7 @@
   :bank_code: 300
   :clearing_code_length: 4
   :serial_number_length: 10
-  :zerofill_serial_number: true
+  :zerofill_serial_number: false
   :include_clearing_code: false
   :validation_scheme: '2.1'
 - :range: [3301, 3399]

--- a/lib/ibandit/sweden/validator.rb
+++ b/lib/ibandit/sweden/validator.rb
@@ -64,7 +64,7 @@ module Ibandit
           length += bank[:clearing_code_length] if bank[:include_clearing_code]
 
           cleaned_account_number = account_number.gsub(/\A0+/, "")
-          if bank[:zerofill_serial_number] && !bank[:include_clearing_code]
+          if !bank[:include_clearing_code]
             cleaned_account_number =
               cleaned_account_number.
                 rjust(bank.fetch(:serial_number_length), "0")

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ibandit
-  VERSION = "1.23.0"
+  VERSION = "1.24.0"
 end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -183,6 +183,74 @@ describe Ibandit::IBAN do
       its(:iban) { is_expected.to eq("SE5412000000012810105723") }
       its(:pseudo_iban) { is_expected.to eq("SEZZX1281XXX0105723") }
       its(:to_s) { is_expected.to eq("SE5412000000012810105723") }
+
+      context "and the clearing code is not part of the IBAN" do
+        context "and the branch code allows for zero-filling of short account numbers" do
+          let(:arg) do
+            {
+              country_code: "SE",
+              branch_code: "6000",
+              account_number: "1234567",
+            }
+          end
+
+          its(:country_code) { is_expected.to eq("SE") }
+          its(:bank_code) { is_expected.to be_nil }
+          its(:branch_code) { is_expected.to eq("6000") }
+          its(:account_number) { is_expected.to eq("001234567") }
+          its(:swift_bank_code) { is_expected.to eq("600") }
+          its(:swift_branch_code) { is_expected.to be_nil }
+          its(:swift_account_number) { is_expected.to eq("00000000001234567") }
+          its(:iban) { is_expected.to eq("SE2260000000000001234567") }
+          its(:pseudo_iban) { is_expected.to eq("SEZZX6000X001234567") }
+          its(:to_s) { is_expected.to eq("SE2260000000000001234567") }
+          its(:valid?) { is_expected.to eq(true) }
+        end
+
+        context "and the branch code does not allow for zero-filling of short account numbers" do
+          let(:arg) do
+            {
+              country_code: "SE",
+              branch_code: "3300",
+              account_number: "1234567",
+            }
+          end
+
+          its(:country_code) { is_expected.to eq("SE") }
+          its(:bank_code) { is_expected.to be_nil }
+          its(:branch_code) { is_expected.to eq("3300") }
+          its(:account_number) { is_expected.to eq("1234567") }
+          its(:swift_bank_code) { is_expected.to eq("300") }
+          its(:swift_branch_code) { is_expected.to be_nil }
+          its(:swift_account_number) { is_expected.to eq("00000000001234567") }
+          its(:iban) { is_expected.to eq("SE4130000000000001234567") }
+          its(:pseudo_iban) { is_expected.to eq("SEZZX3300XXX1234567") }
+          its(:to_s) { is_expected.to eq("SE4130000000000001234567") }
+          its(:valid?) { is_expected.to eq(false) }
+        end
+      end
+
+      context "and the clearing code is part of the IBAN" do
+        let(:arg) do
+          {
+            country_code: "SE",
+            branch_code: "3410",
+            account_number: "1234567",
+          }
+        end
+
+        its(:country_code) { is_expected.to eq("SE") }
+        its(:bank_code) { is_expected.to be_nil }
+        its(:branch_code) { is_expected.to eq("3410") }
+        its(:account_number) { is_expected.to eq("1234567") }
+        its(:swift_bank_code) { is_expected.to eq("300") }
+        its(:swift_branch_code) { is_expected.to be_nil }
+        its(:swift_account_number) { is_expected.to eq("00000034101234567") }
+        its(:iban) { is_expected.to eq("SE1030000000034101234567") }
+        its(:pseudo_iban) { is_expected.to eq("SEZZX3410XXX1234567") }
+        its(:to_s) { is_expected.to eq("SE1030000000034101234567") }
+        its(:valid?) { is_expected.to eq(true) }
+      end
     end
 
     context "when the IBAN was created from a pseudo-IBAN" do


### PR DESCRIPTION
For any account number that starts with a zero, when converted into an IBAN (without a clearing code) and attempting to validate it, we currently over-trim the leading zeroes.  This leads us to incorrectly reject these IBANs.

This change will only use the zero-fill flag when validating local details.  Validating SWIFT details will always zero-fill before validation as the SWIFT account itself is zero-padded.

It also reverts the change to clearing code 3300, after better understanding these accounts.