### PR TITLE
Don't fail SE pseudo-IBAN validation due to check digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.25.0 - February 18, 2025
+
+- `SE` pseudo-ibans no longer fail validation due to the `ZZ` check digit.
+
 ## 1.24.0 - February 18, 2025
 
 - Fix validation for SE IBANs where the account number starts with a 0 and the clearing number is not included in the IBAN

--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -128,6 +128,7 @@ module Ibandit
     end
 
     def valid_check_digits?
+      return true if source == :pseudo_iban && check_digits == Constants::PSEUDO_IBAN_CHECK_DIGITS
       return unless decomposable? && valid_characters?
 
       expected_check_digits = CheckDigit.iban(country_code, bban)

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ibandit
-  VERSION = "1.24.0"
+  VERSION = "1.25.0"
 end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -183,6 +183,7 @@ describe Ibandit::IBAN do
       its(:iban) { is_expected.to eq("SE5412000000012810105723") }
       its(:pseudo_iban) { is_expected.to eq("SEZZX1281XXX0105723") }
       its(:to_s) { is_expected.to eq("SE5412000000012810105723") }
+      its(:valid?) { is_expected.to eq(true) }
 
       context "and the clearing code is not part of the IBAN" do
         context "and the branch code allows for zero-filling of short account numbers" do
@@ -266,9 +267,17 @@ describe Ibandit::IBAN do
       its(:iban) { is_expected.to eq("SE5412000000012810105723") }
       its(:pseudo_iban) { is_expected.to eq("SEZZX1281XXX0105723") }
       its(:to_s) { is_expected.to eq("SE5412000000012810105723") }
+      its(:valid?) { is_expected.to eq(true) }
     end
 
     context "when the IBAN was created from a Swedish IBAN" do
+      context "with check digits that make it look like a pseudo-IBAN" do
+        let(:arg) { "SEZZ30000000031231234567" }
+
+        its(:country_code) { is_expected.to eq("SE") }
+        its(:valid?) { is_expected.to eq(false) }
+      end
+
       context "where the clearing code is part of the account number" do
         let(:arg) { "SE4730000000031231234567" }
 


### PR DESCRIPTION
Swedish pseudo-IBANs will no longer fail validation because of the ZZ check-digits.