### PR TITLE
Gracefully fail account validation if NZ account number is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.26.1 - July 4, 2025
+
+- Gracefully fail validation for NZ accounts if no account number is provided
+
 ## 1.26.0 - July 1, 2025
 
 - Update BLZ data - BLZ_20250609

--- a/lib/ibandit/iban.rb
+++ b/lib/ibandit/iban.rb
@@ -56,12 +56,14 @@ module Ibandit
     end
 
     def account_number
+      return nil if @account_number.nil?
       return @account_number unless country_code == "NZ"
 
       @account_number[0..6]
     end
 
     def account_number_suffix
+      return nil if @account_number.nil?
       return nil unless country_code == "NZ"
 
       @account_number[7..]

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ibandit
-  VERSION = "1.26.0"
+  VERSION = "1.26.1"
 end

--- a/spec/ibandit/iban_spec.rb
+++ b/spec/ibandit/iban_spec.rb
@@ -799,6 +799,24 @@ describe Ibandit::IBAN do
         its(:to_s) { is_expected.to eq("") }
       end
 
+      context "with a nil account number" do
+        let(:account_number) { nil }
+
+        its(:country_code) { is_expected.to eq("NZ") }
+        its(:bank_code) { is_expected.to eq("11") }
+        its(:branch_code) { is_expected.to eq("2222") }
+        its(:account_number) { is_expected.to eq(nil) }
+        its(:account_number_suffix) { is_expected.to eq(nil) }
+        its(:swift_bank_code) { is_expected.to eq("11") }
+        its(:swift_branch_code) { is_expected.to eq("2222") }
+        its(:swift_account_number) { is_expected.to eq(nil) }
+        its(:swift_national_id) { is_expected.to eq("112222") }
+        its(:iban) { is_expected.to be_nil }
+        its(:pseudo_iban) { is_expected.to eq(nil) }
+        its(:valid?) { is_expected.to eq(false) }
+        its(:to_s) { is_expected.to eq("") }
+      end
+
       context "with bank and branch code embedded in account_number field" do
         let(:arg) do
           {


### PR DESCRIPTION
Fix a bug that raised an error due to dereferencing a nil value.