### PR TITLE
Update translation for invalid checksum

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,7 +1,7 @@
 de:
   ibandit:
     invalid_country_code: "'%{country_code}' ist kein gültiges IBAN-Länderkennzeichen gemäß ISO 3166-1"
-    invalid_check_digits: "Prüfziffer hat Betragsprüfung nicht bestanden. (%{expected_check_digits} Zeichen erwartet, %{check_digits} angegeben)."
+    invalid_check_digits: "Prüfziffer ist ungültig (%{expected_check_digits} erwartet, %{check_digits} angegeben)."
     invalid_length: "Länge entspricht nicht der SWIFT-Spezifikation (%{expected_length} Zeichen erwartet, %{length} angegeben)"
     is_required: "ist erforderlich"
     wrong_length: "hat nicht die richtige Länge (sollte %{expected} Zeichen haben)"


### PR DESCRIPTION
The previous translation for `invalid_check_digits` was something like:

> Check digits did not pass sum test. (01 digits expected, 02 received).

This PR updates the wording (and punctuation) to something akin to:

> Check digits are invalid (01 expected, 02 received).

N.B. I'm a native German speaker.