### PR TITLE
Add Klarna Bank SE clearing code config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.32.0 - July 2, 2026
+
+- Update SE data - added Klarna Bank
+
 ## 1.31.0 - June 8, 2026
 
 - Update BLZ data - BLZ_20260608

--- a/data/raw/swedish_bank_lookup.yml
+++ b/data/raw/swedish_bank_lookup.yml
@@ -445,3 +445,11 @@
   :zerofill_serial_number: false
   :include_clearing_code: true
   :validation_scheme: '1.2'
+- :range: [9780, 9789]
+  :bank: Klarna Bank
+  :bank_code: 978
+  :clearing_code_length: 4
+  :serial_number_length: 7
+  :zerofill_serial_number: false
+  :include_clearing_code: true
+  :validation_scheme: '1.2'

--- a/lib/ibandit/version.rb
+++ b/lib/ibandit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ibandit
-  VERSION = "1.31.0"
+  VERSION = "1.32.0"
 end


### PR DESCRIPTION
Klarna Bank's clearing range (9780-9789) is missing from the Swedish bank lookup data, causing local details validation to fail for customer bank accounts using it. Adds the range per Bankgirot's published account number reference: [Bankernas kontonummer / Bank Account Numbers in Swedish Banks](https://www.bankgirot.se/globalassets/dokument/anvandarmanualer/bankernaskontonummeruppbyggnad_anvandarmanual_sv.pdf) (page 3, "Klarna Bank | 9780-9789 | 00000xxxxxxC | 2").